### PR TITLE
chore: block push if util has no test file

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+# check if all utils have a test file
+bash scripts/compareSrcAndTests.bash

--- a/scripts/compareSrcAndTests.bash
+++ b/scripts/compareSrcAndTests.bash
@@ -1,0 +1,43 @@
+for UTIL in src/**/*.ts;
+do
+    # cache util file name
+    ## remove the longest string from left to right
+    ## which ends in "/"
+    utilFileName=${UTIL##*/}
+    ## remove the longest string from right to left
+    ## which starts with "."
+    utilFileName=${utilFileName%%.*}
+
+    # if util is `index.ts` skip to the next element
+    if [ "$utilFileName" == "index" ];
+    then
+        continue
+    fi;
+
+    utilHasTest=0
+
+    for TEST in tests/**/*.test.ts;
+    do
+        # cache test file name
+        ## remove the longest string from left to right
+        ## which ends in "/"
+        testFileName=${TEST##*/}
+        ## remove the longest string from right to left
+        ## which starts with "."
+        testFileName=${testFileName%%.*}
+
+        # compare util and test name
+        # is test is present, then it should set `utilHasTest` to true
+        if [ "$utilFileName" == "$testFileName" ];
+        then
+            utilHasTest=1
+        fi;
+    done
+
+    # exit with error if util does not have a test
+    if [ "$utilHasTest" == "0" ];
+    then
+        echo "The file \`$utilFileName.ts\` does not have any tests. Please add tests for the features and functions in this file."
+        exit 1
+    fi;
+done

--- a/scripts/compareSrcAndTests.bash
+++ b/scripts/compareSrcAndTests.bash
@@ -1,27 +1,33 @@
-for UTIL in src/**/*.ts;
+for utilPath in src/**/*.ts;
 do
-    # cache util file name
-    ## remove the longest string from left to right
-    ## which ends in "/"
-    utilFileName=${UTIL##*/}
-    ## remove the longest string from right to left
-    ## which starts with "."
-    utilFileName=${utilFileName%%.*}
-
     # if util is `index.ts` skip to the next element
-    if [ "$utilFileName" == "index" ];
+    if [ $utilPath == "src/index.ts" ] || [ $utilPath == "src/constants/index.ts" ];
     then
         continue
     fi;
 
+    # ignore src/typechain/ folder
+    if [[ $utilPath == src/typechain/* ]];
+    then
+        continue
+    fi;
+
+    # cache util file name
+    ## remove the longest string from left to right
+    ## which ends in "/"
+    utilFileName=${utilPath##*/}
+    ## remove the longest string from right to left
+    ## which starts with "."
+    utilFileName=${utilFileName%%.*}
+
     utilHasTest=0
 
-    for TEST in tests/**/*.test.ts;
+    for testPath in tests/**/*.test.ts;
     do
         # cache test file name
         ## remove the longest string from left to right
         ## which ends in "/"
-        testFileName=${TEST##*/}
+        testFileName=${testPath##*/}
         ## remove the longest string from right to left
         ## which starts with "."
         testFileName=${testFileName%%.*}

--- a/scripts/generateSpecificTypechain.bash
+++ b/scripts/generateSpecificTypechain.bash
@@ -10,6 +10,12 @@ do
         continue
     fi;
 
+    # ignore src/typechain/ folder
+    if [[ $utilPath == src/typechain/* ]];
+    then
+        continue
+    fi;
+
     # cache util file name
     ## remove the shortest string from left to right which ends in "/"
     utilName=${utilPath#*/}

--- a/scripts/ignoreTypesFolder.bash
+++ b/scripts/ignoreTypesFolder.bash
@@ -1,9 +1,0 @@
-for FILE in types/*.ts;
-do
-echo '// @ts-nocheck' | cat - $FILE > temp && mv temp $FILE
-done
-
-for FILE in types/**/*.ts;
-do
-echo '// @ts-nocheck' | cat - $FILE > temp && mv temp $FILE
-done


### PR DESCRIPTION
# What does this PR introduce?

This PR introduces a safety development feature. It blocks push if there exists a util file, _e.g. `src/LSP6/encodeAllowedCalls.ts`_, but the test for it is missing, _e.g. `tests/LSP6/encodeAllowedCalls.test.ts`_.
This will help to ensure that no feature is added without adding tests.
Of course this does not prevent you from having poor tests.