### PR TITLE
chore: generate types dynamically

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,3 @@
-types/*
+/src/typechain/*
 node_modules/*
 /dist

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 /dist
 
 # Typechain smart contracts types
-/types
+/src/typechain

--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
     "scripts": {
         "lint": "eslint . --ext .ts",
         "prettier": "prettier -w .",
+        "clean": "rm -rf dist && rm -rf src/typechain",
         "build:docs": "typedoc --plugin typedoc-plugin-markdown --out docs src/index.ts",
-        "build:types": "typechain --target=ethers-v6 --out-dir types ./node_modules/@lukso/lsp-smart-contracts/artifacts/*.json",
-        "build": "rm -rf dist/lib && rm -rf types && npm run lint && npm run build:types && vite build",
+        "build:types:all": "typechain --target=ethers-v6 --out-dir src/typechain ./node_modules/@lukso/lsp-smart-contracts/artifacts/*.json",
+        "build:types:specific": "bash scripts/generateSpecificTypechain.bash",
+        "build": "npm run clean && npm run lint && npm run build:types:specific && vite build",
         "test": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' mocha -r ts-node/register 'tests/**/*.ts'",
         "prepare": "husky install",
         "release": "standard-version",

--- a/scripts/generateSpecificTypechain.bash
+++ b/scripts/generateSpecificTypechain.bash
@@ -1,0 +1,106 @@
+typechainDependencies=""
+
+# check the dependencies of utils
+# if dependency will have its tests run, then run the tests for the unchanged util as well
+for utilPath in src/**/*.ts;
+do
+    # if util is `index.ts` skip to the next element
+    if [ $utilPath == "src/index.ts" ] || [ $utilPath == "src/constants/index.ts" ];
+    then
+        continue
+    fi;
+
+    # cache util file name
+    ## remove the shortest string from left to right which ends in "/"
+    utilName=${utilPath#*/}
+    ## remove the longest string from right to left which starts with "."
+    utilName=${utilName%%.*}
+
+    # get the imports of the util
+    imports=$(grep "^import" $utilPath)
+
+    index=1;
+    # read each line from `imports`
+    while read line; do 
+        # remove the longest string from left to right which ends in "from "
+        dependency=${line##*"from "}
+        # remove the shortest string from left to right which ends in "'"
+        dependency=${dependency#*\'}
+        # remove the shortest string from right to left which satrts with "'"
+        dependency=${dependency%\'*}
+
+        # check if dependency starts with './' or '../', which means it is from 'src/'
+        if [[ $dependency == ../typechain* ]];
+        then
+            # remove the shortest string from left to right which ends in "{"
+            importedContracts=${line#*"{"}
+            # remove the shortest string from right to left which satrts with "}"
+            importedContracts=${importedContracts%"}"*}
+            # clear the whitespaces
+            importedContracts=$(echo $importedContracts | sed 's/ //g')
+
+            # check if there are multiple imported contracts or signgle
+            if [[ $importedContracts == *,* ]];
+            then
+                # transform the imported contracts to an array
+                IFS="," read -a contractNames <<< $importedContracts
+
+                # loop through the imported contracts
+                for contractName in $contractNames
+                do
+                    # if the contract ends with "__factory"
+                    if [[ $contractName == *__factory ]];
+                    then
+                        # remove the shortest string from right to left which ends in "__factory"
+                        contractName=${contractName%"__factory"*}
+
+                        # check if typechain dependency is present
+                        # add it if its not
+                        if [[ $typechainDependencies != *$contractName* ]];
+                        then
+                            typechainDependencies+=" $contractName"
+                        fi;
+                    else
+                        # check if typechain dependency is present
+                        # add it if its not
+                        if [[ $typechainDependencies != *$contractName* ]];
+                        then
+                            typechainDependencies+=" $contractName"
+                        fi;
+                    fi;
+                done
+            else
+                # at this point we assume its a signle imported contract
+                contractName=$importedContracts
+                # if the contract ends with "__factory"
+                if [[ $contractName == *__factory ]];
+                then
+                    # remove the shortest string from right to left which ends in "__factory"
+                    contractName=${contractName%"__factory"*}
+
+                    # check if typechain dependency is present
+                    # add it if its not
+                    if [[ $typechainDependencies != *$contractName* ]];
+                    then
+                        typechainDependencies+=" $contractName"
+                    fi;
+                else
+                    # check if typechain dependency is present
+                    # add it if its not
+                    if [[ $typechainDependencies != *$contractName* ]];
+                    then
+                        typechainDependencies+=" $contractName"
+                    fi;
+                fi;
+            fi;
+        fi;
+        index=$(($index+1)); 
+    done <<< "$imports"
+done
+
+typechainCommand="npx typechain --target=ethers-v6 --out-dir src/typechain"
+for contractName in $typechainDependencies
+do
+    typechainCommand+=" ./node_modules/@lukso/lsp-smart-contracts/artifacts/$contractName.json"
+done
+$typechainCommand

--- a/src/LSP2/removeElementFromArrayAndMap.ts
+++ b/src/LSP2/removeElementFromArrayAndMap.ts
@@ -2,7 +2,7 @@
 import { BytesLike, concat, isHexString, toBeHex } from 'ethers';
 
 // types
-import { UniversalProfile } from '../../types';
+import { UniversalProfile } from '../typechain';
 import { generateArrayElementKeyAtIndex } from './generateArrayElementKeyAtIndex';
 import { generateMappingKey } from './generateMappingKey';
 

--- a/src/LSP3/getProfileMetadata.ts
+++ b/src/LSP3/getProfileMetadata.ts
@@ -13,7 +13,7 @@ import { decodeJsonUrl } from '../LSP2/decodeJsonUrl';
 import { isProfileMetadata } from './isProfileMetadata';
 
 // types
-import { UniversalProfile } from '../../types';
+import { UniversalProfile } from '../typechain';
 
 /**
  * Returns a object of type LSP3ProfileMetadata.

--- a/src/LSP5/generateReceivedAssetKeys.ts
+++ b/src/LSP5/generateReceivedAssetKeys.ts
@@ -9,7 +9,7 @@ import { generateMappingKey } from '../LSP2/generateMappingKey';
 import { generateArrayElementKeyAtIndex } from '../LSP2/generateArrayElementKeyAtIndex';
 
 // types
-import { UniversalProfile } from '../../types';
+import { UniversalProfile } from '../typechain';
 
 /**
  * Generate an array of Data Key/Value pairs to be set on the receiver address after receiving assets.

--- a/src/LSP5/generateSentAssetKeys.ts
+++ b/src/LSP5/generateSentAssetKeys.ts
@@ -12,7 +12,7 @@ import { removeLastElementFromArrayAndMap } from '../LSP2/removeLastElementFromA
 import { removeElementFromArrayAndMap } from '../LSP2/removeElementFromArrayAndMap';
 
 // types
-import { UniversalProfile } from '../../types';
+import { UniversalProfile } from '../typechain';
 
 /**
  * Generate an array of Data Key/Value pairs to be set on the sender address after sending assets.

--- a/tsconfig.es5.json
+++ b/tsconfig.es5.json
@@ -4,10 +4,10 @@
         "target": "ES5",
         "lib": ["ES2020", "DOM"],
         "declaration": true,
-        "outDir": "./dist/lib/es5",
+        "outDir": "./dist/es5",
         "moduleResolution": "NodeNext",
         "skipLibCheck": true
     },
     "include": ["src/**/*"],
-    "exclude": ["node_modules", "types/**/*", "dist"]
+    "exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -4,10 +4,10 @@
         "target": "ES5",
         "lib": ["ES2020", "DOM"],
         "declaration": true,
-        "outDir": "./dist/lib/es6",
+        "outDir": "./dist/es6",
         "moduleResolution": "NodeNext",
         "skipLibCheck": true
     },
     "include": ["src/**/*", "tests/**/*", "vite.config.ts"],
-    "exclude": ["node_modules", "types/**/*", "dist"]
+    "exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,10 +4,10 @@
         "target": "ES5",
         "lib": ["ES2020", "DOM"],
         "declaration": true,
-        "outDir": "./dist/lib/es6",
+        "outDir": "./dist/es6",
         "moduleResolution": "NodeNext",
         "skipLibCheck": true
     },
     "include": ["src/**/*"],
-    "exclude": ["node_modules", "types/**/*", "dist"]
+    "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
# What does this PR introduce?

This PR makes it so type chain is used to generate only for the contracts that are used, instead of everything.
This allows for having the published package less cluttered with multiple unused types, contract bytecodes or contract abis which takes a lot of space