### PR TITLE
feat: add `encodePermissions(..)` utility function

### DIFF
--- a/src/LSP6/encodePermissions.ts
+++ b/src/LSP6/encodePermissions.ts
@@ -1,0 +1,60 @@
+import { PERMISSIONS } from '@lukso/lsp-smart-contracts';
+import { isHexString, toBeHex } from 'ethers';
+
+/**
+ * Generate a `BitArray` of permissions. The result can be user for `AddressPermissions:Permissions:<address>`.
+ *
+ * @since v0.0.2
+ * @category LSP6
+ * @param permissions An array of LSP6 permissions, LSP6 permission names, numbers, booleans or any combination of the previously enumerated types.
+ *
+ * @return A `BitArray` that can be use as LSP6 controller permissions.
+ *
+ * @see https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-6-KeyManager.md
+ * @example
+ * ```
+ * encodePermissions([
+ *   "0x0000000000000000000000000000000000000000000000000000000000000001", //CHANGEOWNER
+ *   "0x0000000000000000000000000000000000000000000000000000000000000002", //ADDCONTROLLER
+ *   "0x0000000000000000000000000000000000000000000000000000000000000800", //CALL
+ *   "0x0000000000000000000000000000000000000000000000000000000000040000", //SETDATA
+ * ]) //=> `0x0000000000000000000000000000000000000000000000000000000000040803`
+ * encodePermissions([
+ *   true,  // `0x0000000000000000000000000000000000000000000000000000000000000001` - CHANGEOWNER
+ *   true,  // `0x0000000000000000000000000000000000000000000000000000000000000002` - ADDCONTROLLER
+ *   false, // `0x0000000000000000000000000000000000000000000000000000000000000000` - EDITPERMISSIONS
+ *   true,  // `0x0000000000000000000000000000000000000000000000000000000000000008` - ADDEXTENSIONS
+ * ]) //=> `0x000000000000000000000000000000000000000000000000000000000000000b`
+ * encodePermissions([
+ *   1, // `0x0000000000000000000000000000000000000000000000000000000000000001` - CHANGEOWNER
+ *   2, // `0x0000000000000000000000000000000000000000000000000000000000000002` - ADDCONTROLLER
+ *   4, // `0x0000000000000000000000000000000000000000000000000000000000000004` - EDITPERMISSIONS
+ * ]) //=> `0x0000000000000000000000000000000000000000000000000000000000000007`
+ * ```
+ */
+export function encodePermissions(permissions: (bigint | number | boolean | string)[]) {
+    let result = BigInt(0);
+
+    permissions.forEach((permission: bigint | number | boolean | string, index) => {
+        if (typeof permission === 'string') {
+            if (!isHexString(permission)) {
+                if (PERMISSIONS[permission]) {
+                    const permissionAsBN = BigInt(PERMISSIONS[permission]);
+                    result |= BigInt(permissionAsBN);
+                    return;
+                }
+
+                throw new Error(`Permission: '${permission}' is not a hex string.`);
+            }
+        } else if (typeof permission === 'boolean') {
+            const permissionAsBN = BigInt(permission);
+            result |= BigInt(permissionAsBN) << BigInt(index);
+            return;
+        }
+
+        const permissionAsBN = BigInt(permission);
+        result |= BigInt(permissionAsBN);
+    });
+
+    return toBeHex(result, 32);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,8 +28,9 @@ export { generateReceivedAssetKeys } from './LSP5/generateReceivedAssetKeys';
 export { generateSentAssetKeys } from './LSP5/generateSentAssetKeys';
 
 // ------ LSP6 ------
+export { createValidityTimestamp } from './LSP6/createValidityTimestamp';
 export { decodeAllowedCalls } from './LSP6/decodeAllowedCalls';
 export { encodeAllowedCalls } from './LSP6/encodeAllowedCalls';
 export { decodeAllowedERC725YDataKeys } from './LSP6/decodeAllowedERC725YDataKeys';
 export { encodeAllowedERC725YDataKeys } from './LSP6/encodeAllowedERC725YDataKeys';
-export { createValidityTimestamp } from './LSP6/createValidityTimestamp';
+export { encodePermissions } from './LSP6/encodePermissions';

--- a/tests/LSP6/encodePermissions.test.ts
+++ b/tests/LSP6/encodePermissions.test.ts
@@ -1,0 +1,165 @@
+import { PERMISSIONS } from '@lukso/lsp-smart-contracts';
+import { toBeHex } from 'ethers';
+import { expect } from 'chai';
+
+import { encodePermissions } from '../../src';
+
+describe('encodePermissions', () => {
+    it('should pass and combine permissions properly, 0 perimissions', () => {
+        const expectedResult = toBeHex(0, 32);
+
+        expect(encodePermissions([])).to.equal(expectedResult);
+    });
+
+    describe('testing parameter as `string[]`', () => {
+        it('should throw if a permission is not hex and not a valid permission name', () => {
+            expect(() =>
+                encodePermissions([
+                    PERMISSIONS.CHANGEOWNER,
+                    'some text',
+                    PERMISSIONS.ADDEXTENSIONS,
+                ]),
+            ).to.throw("Permission: 'some text' is not a hex string.");
+        });
+
+        it('should pass and combine permissions properly', () => {
+            const expectedResult = toBeHex(
+                BigInt(PERMISSIONS.CHANGEOWNER) |
+                    BigInt(PERMISSIONS.ADDCONTROLLER) |
+                    BigInt(PERMISSIONS.CALL) |
+                    BigInt(PERMISSIONS.SETDATA),
+                32,
+            );
+
+            expect(
+                encodePermissions([
+                    PERMISSIONS.CHANGEOWNER,
+                    PERMISSIONS.ADDCONTROLLER,
+                    PERMISSIONS.CALL,
+                    PERMISSIONS.SETDATA,
+                ]),
+            ).to.equal(expectedResult);
+        });
+
+        it('should pass and combine permissions properly, repeating permission', () => {
+            const expectedResult = toBeHex(
+                BigInt(PERMISSIONS.CHANGEOWNER) |
+                    BigInt(PERMISSIONS.ADDCONTROLLER) |
+                    BigInt(PERMISSIONS.CALL) |
+                    BigInt(PERMISSIONS.SETDATA),
+                32,
+            );
+
+            expect(
+                encodePermissions([
+                    PERMISSIONS.CHANGEOWNER,
+                    PERMISSIONS.CHANGEOWNER,
+                    PERMISSIONS.ADDCONTROLLER,
+                    PERMISSIONS.CALL,
+                    PERMISSIONS.SETDATA,
+                    PERMISSIONS.SETDATA,
+                ]),
+            ).to.equal(expectedResult);
+        });
+
+        it('should pass and allow a valid LSP permission name', () => {
+            const expectedResult = toBeHex(
+                BigInt(PERMISSIONS.CHANGEOWNER) |
+                    BigInt(PERMISSIONS.SETDATA) |
+                    BigInt(PERMISSIONS.ADDEXTENSIONS),
+                32,
+            );
+
+            expect(encodePermissions(['CHANGEOWNER', 'SETDATA', 'ADDEXTENSIONS'])).to.equal(
+                expectedResult,
+            );
+        });
+    });
+
+    describe('testing parameter as `number[]`', () => {
+        it('should pass and combine permissions properly', () => {
+            const expectedResult = toBeHex(15 | 6 | 49 | 170, 32);
+
+            expect(encodePermissions([15, 6, 49, 170])).to.equal(expectedResult);
+        });
+
+        it('should pass and combine permissions properly, repeating permission', () => {
+            const expectedResult = toBeHex(15 | 6 | 49 | 170, 32);
+
+            expect(encodePermissions([15, 15, 6, 49, 170, 170])).to.equal(expectedResult);
+        });
+    });
+
+    describe('testing parameter as `bigint[]`', () => {
+        it('should pass and combine permissions properly', () => {
+            const expectedResult = toBeHex(
+                BigInt('18371249837432') |
+                    BigInt('1324876374612367') |
+                    BigInt('836421867624') |
+                    BigInt('5723167862178'),
+                32,
+            );
+
+            expect(
+                encodePermissions([
+                    BigInt('18371249837432'),
+                    BigInt('1324876374612367'),
+                    BigInt('836421867624'),
+                    BigInt('5723167862178'),
+                ]),
+            ).to.equal(expectedResult);
+        });
+
+        it('should pass and combine permissions properly, repeating permission', () => {
+            const expectedResult = toBeHex(
+                BigInt('18371249837432') |
+                    BigInt('1324876374612367') |
+                    BigInt('836421867624') |
+                    BigInt('5723167862178'),
+                32,
+            );
+
+            expect(
+                encodePermissions([
+                    BigInt('18371249837432'),
+                    BigInt('18371249837432'),
+                    BigInt('1324876374612367'),
+                    BigInt('836421867624'),
+                    BigInt('5723167862178'),
+                    BigInt('5723167862178'),
+                ]),
+            ).to.equal(expectedResult);
+        });
+    });
+
+    describe('testing parameter as `bool[]`', () => {
+        it('should pass and combine permissions properly', () => {
+            const expectedResult = toBeHex(
+                (BigInt(true) << BigInt(0)) |
+                    (BigInt(true) << BigInt(1)) |
+                    (BigInt(false) << BigInt(2)) |
+                    (BigInt(true) << BigInt(3)),
+                32,
+            );
+
+            expect(encodePermissions([true, true, false, true])).to.equal(expectedResult);
+        });
+    });
+
+    describe('testing a combination of types: string, number, bigint', () => {
+        it('should pass and combine permissions properly with mutiple types', () => {
+            const expectedResult = toBeHex(
+                BigInt(PERMISSIONS.CALL) |
+                    (BigInt(true) << BigInt(1)) |
+                    BigInt('5723167862178') |
+                    BigInt(PERMISSIONS.SETDATA) |
+                    BigInt(15),
+                32,
+            );
+
+            expect(
+                encodePermissions([PERMISSIONS.CALL, true, BigInt('5723167862178'), 'SETDATA', 15]),
+            ).to.equal(expectedResult);
+        });
+    });
+});


### PR DESCRIPTION
# What does this PR introduce?

This PR adds a new utility function in the LSP6 folder for combining multiple permissions.