### PR TITLE
chore: block commit if a test contains `.only`

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,9 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+# Check if there are tests containing `.only`
+bash scripts/searchTestsForOnly.bash
+
 if [[ $(git diff origin/main --name-only src/ tests/) != "" ]];
 then
     npm test

--- a/scripts/searchTestsForOnly.bash
+++ b/scripts/searchTestsForOnly.bash
@@ -1,0 +1,20 @@
+invalidTests=""
+for test in tests/**/*.ts
+do
+    if grep -q describe.only "$test" ||
+       grep -q it.only "$test";
+    then
+        invalidTests+="$test "
+    fi
+done
+if [[ $invalidTests != "" ]];
+then
+    echo "Some files have '.only'. Please remove before commiting."
+    
+    for test in $invalidTests
+    do
+        echo "'$test'"    
+    done
+
+    exit 1
+fi;


### PR DESCRIPTION
# What does this PR introduce?

This PR introduces a check that blocks a commit if any of your tests contain a `.only`.