### PR TITLE
feat: add `decodePermissions(...)` utility function

### DIFF
--- a/src/LSP6/decodePermissions.ts
+++ b/src/LSP6/decodePermissions.ts
@@ -1,0 +1,135 @@
+// import { PERMISSIONS } from '@lukso/lsp-smart-contracts';
+import { BytesLike, ZeroHash, isHexString, stripZerosLeft, toBeHex } from 'ethers';
+import { PERMISSIONS } from '@lukso/lsp-smart-contracts';
+import { LSP6PermissionName } from '../constants';
+
+/**
+ * Decode a hex value, containing a `BitArray` of permissions. The `AddressPermissions:Permissions:<address>` can be decoded using this function.
+ *
+ * @since v0.0.2
+ * @category LSP6
+ * @param permissions A hex value, containing a BitArray of permissions.
+ * @param decodedPermissionsType Optional param, defaults to `LSP6PermissionName`.
+ * Can be used to specfiy the type of the return array. Options:
+ * - `BytesLike`
+ * - `bigint`
+ * - `boolean`
+ * - `LSP6PermissionName`
+ *
+ * @return An array of decoded permissions.
+ *
+ * @throws
+ *
+ * @see https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-6-KeyManager.md
+ * @example
+ * ```
+ * decodePermissions([
+ *   `0x0000000000000000000000000000000000000000000000000000000000040803`
+ * ]) //=> new Set([ CHANGEOWNER, ADDCONTROLLER, CALL, SETDATA ])
+ * decodePermissions([
+ *   `0x0000000000000000000000000000000000000000000000000000000000040803`,
+ *   'LSP6PermissionName'
+ * ]) //=> new Set([ CHANGEOWNER, ADDCONTROLLER, CALL, SETDATA ])
+ * decodePermissions([
+ *   `0x0000000000000000000000000000000000000000000000000000000000040803`,
+ *   'BytesLike'
+ * ]) //=>
+ * // new Set([
+ * //   '0x0000000000000000000000000000000000000000000000000000000000000001',
+ * //   '0x0000000000000000000000000000000000000000000000000000000000000002',
+ * //   '0x0000000000000000000000000000000000000000000000000000000000000800',
+ * //   '0x0000000000000000000000000000000000000000000000000000000000040000',
+ * // ])
+ * decodePermissions([
+ *   `0x0000000000000000000000000000000000000000000000000000000000040803`,
+ *   'bigint'
+ * ]) //=> new Set([ 1n, 2n, 2048n, 262144n ])
+ * decodePermissions([
+ *   `0x0000000000000000000000000000000000000000000000000000000000000003`,
+ *   'boolean'
+ * ]) //=> [ true, true, false, false, false, false, false, false ]
+ * ```
+ */
+export function decodePermissions(permissions: string | BytesLike): Set<LSP6PermissionName>;
+export function decodePermissions(
+    permissions: string | BytesLike,
+    decodedPermissionsType: 'BytesLike',
+): Set<BytesLike>;
+export function decodePermissions(
+    permissions: string | BytesLike,
+    decodedPermissionsType: 'bigint',
+): Set<bigint>;
+export function decodePermissions(
+    permissions: string | BytesLike,
+    decodedPermissionsType: 'boolean',
+): boolean[];
+export function decodePermissions(
+    permissions: string | BytesLike,
+    decodedPermissionsType: 'LSP6PermissionName',
+): Set<LSP6PermissionName>;
+export function decodePermissions(
+    permissions: string | BytesLike,
+    decodedPermissionsType?: 'BytesLike' | 'bigint' | 'boolean' | 'LSP6PermissionName',
+): Set<BytesLike | bigint | LSP6PermissionName> | boolean[] {
+    if (permissions === ZeroHash || permissions === '') {
+        throw new Error('There are no permissions to decode');
+    }
+
+    if (!isHexString(permissions)) {
+        throw new Error(`Permissions is not hex. permissions: '${permissions}'`);
+    }
+
+    decodedPermissionsType = decodedPermissionsType ? decodedPermissionsType : 'LSP6PermissionName';
+
+    const zeroStrippedPermissions = stripZerosLeft(permissions);
+    const bigIntPermissions = BigInt(zeroStrippedPermissions);
+
+    if (decodedPermissionsType === 'boolean') {
+        const decodedPermissions: boolean[] = [];
+
+        for (let index = 0; index < zeroStrippedPermissions.length * 4; index++) {
+            const bigIntPermission = (BigInt(1) << BigInt(index)) & bigIntPermissions;
+            const booleanPermissions = bigIntPermission !== BigInt(0);
+
+            decodedPermissions[index] = booleanPermissions;
+        }
+
+        return decodedPermissions;
+    } else {
+        const decodedPermissionsSet: Set<BytesLike | bigint | LSP6PermissionName> = new Set([]);
+
+        for (let index = 0; index < zeroStrippedPermissions.length * 4; index++) {
+            const bigIntPermission = (BigInt(1) << BigInt(index)) & bigIntPermissions;
+
+            if (decodedPermissionsType === 'BytesLike') {
+                const bytesLikePermissions = toBeHex(bigIntPermission, 32);
+
+                if (bytesLikePermissions !== ZeroHash) {
+                    decodedPermissionsSet.add(bytesLikePermissions);
+                }
+            } else if (decodedPermissionsType === 'bigint') {
+                if (bigIntPermission !== BigInt(0)) {
+                    decodedPermissionsSet.add(bigIntPermission);
+                }
+            } else if (decodedPermissionsType === 'LSP6PermissionName') {
+                const bytesLikePermissions = toBeHex(bigIntPermission, 32);
+
+                if (bytesLikePermissions !== ZeroHash) {
+                    const permissionName = Object.getOwnPropertyNames(PERMISSIONS).filter(
+                        (permission) => PERMISSIONS[permission] === bytesLikePermissions,
+                    )[0];
+
+                    if (permissionName) {
+                        decodedPermissionsSet.add(permissionName);
+                    } else {
+                        throw new Error(
+                            `LSP6 permission does not exist. Permission: ${bytesLikePermissions}`,
+                        );
+                    }
+                }
+            }
+        }
+
+        return decodedPermissionsSet;
+    }
+}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,9 @@
 import { BytesLike } from 'ethers';
+import { PERMISSIONS } from '@lukso/lsp-smart-contracts';
+
+// generate types from PERMISSIONS imported from `@lukso/lsp-smart-contracts`
+export type LSP6PermissionName = keyof typeof PERMISSIONS;
+export type LSP6Permission = (typeof PERMISSIONS)[LSP6PermissionName];
 
 export interface LSP3ProfileMetadata {
     LSP3Profile: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,3 +39,4 @@ export { encodeAllowedCalls } from './LSP6/encodeAllowedCalls';
 export { decodeAllowedERC725YDataKeys } from './LSP6/decodeAllowedERC725YDataKeys';
 export { encodeAllowedERC725YDataKeys } from './LSP6/encodeAllowedERC725YDataKeys';
 export { encodePermissions } from './LSP6/encodePermissions';
+export { decodePermissions } from './LSP6/decodePermissions';

--- a/tests/LSP6/decodePermissions.test.ts
+++ b/tests/LSP6/decodePermissions.test.ts
@@ -1,0 +1,182 @@
+import { PERMISSIONS } from '@lukso/lsp-smart-contracts';
+import { ZeroHash, toBeHex } from 'ethers';
+import { expect } from 'chai';
+
+import { decodePermissions } from '../../src';
+
+describe('decodePermissions', () => {
+    it('should throw, passing empty string as permissions', () => {
+        expect(() => decodePermissions('')).to.throw('There are no permissions to decode');
+    });
+
+    it('should throw, passing `ZeroHash` as permissions', () => {
+        expect(() => decodePermissions(ZeroHash)).to.throw('There are no permissions to decode');
+    });
+
+    it('should throw, passing UTF8 string as permissions', () => {
+        const permissions = 'Some random string';
+
+        expect(() => decodePermissions(permissions)).to.throw(
+            `Permissions is not hex. permissions: '${permissions}'`,
+        );
+    });
+
+    it('should pass, testing return value as `BytesLike[]`', () => {
+        const expectedPermissions = [
+            PERMISSIONS.CHANGEOWNER,
+            PERMISSIONS.ADDCONTROLLER,
+            PERMISSIONS.CALL,
+            PERMISSIONS.SETDATA,
+        ];
+
+        expect(
+            Array.from(
+                decodePermissions(
+                    toBeHex(
+                        BigInt(PERMISSIONS.CHANGEOWNER) |
+                            BigInt(PERMISSIONS.ADDCONTROLLER) |
+                            BigInt(PERMISSIONS.CALL) |
+                            BigInt(PERMISSIONS.SETDATA),
+                        32,
+                    ),
+                    'BytesLike',
+                ),
+            ),
+        ).to.deep.equal(expectedPermissions);
+    });
+
+    it('should pass, testing return value as `bigint[]`', () => {
+        const expectedPermissions = [
+            BigInt(PERMISSIONS.CHANGEOWNER),
+            BigInt(PERMISSIONS.ADDCONTROLLER),
+            BigInt(PERMISSIONS.CALL),
+            BigInt(PERMISSIONS.SETDATA),
+        ];
+
+        expect(
+            Array.from(
+                decodePermissions(
+                    toBeHex(
+                        BigInt(PERMISSIONS.CHANGEOWNER) |
+                            BigInt(PERMISSIONS.ADDCONTROLLER) |
+                            BigInt(PERMISSIONS.CALL) |
+                            BigInt(PERMISSIONS.SETDATA),
+                        32,
+                    ),
+                    'bigint',
+                ),
+            ),
+        ).to.deep.equal(expectedPermissions);
+    });
+
+    it('should pass, testing return value as `boolean[]`', () => {
+        // because the `SETDATA` permissions is the 19th `Bit` in the `BitArray`
+        // it means that `SETDATA` would be situated in the 3rd byte from left to right
+        // and because each bytes has 8 bits, the retuned array would have 32 (8 bits * 3 bytes) elements
+        const expectedPermissions = [
+            true,
+            true,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            true,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            true,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+        ];
+
+        expect(
+            decodePermissions(
+                toBeHex(
+                    BigInt(PERMISSIONS.CHANGEOWNER) |
+                        BigInt(PERMISSIONS.ADDCONTROLLER) |
+                        BigInt(PERMISSIONS.CALL) |
+                        BigInt(PERMISSIONS.SETDATA),
+                    32,
+                ),
+                'boolean',
+            ),
+        ).to.deep.equal(expectedPermissions);
+    });
+
+    it('should pass, testing return value as `LSP6PermissionName[]`', () => {
+        const expectedPermissions = ['CHANGEOWNER', 'ADDCONTROLLER', 'CALL', 'SETDATA'];
+
+        expect(
+            Array.from(
+                decodePermissions(
+                    toBeHex(
+                        BigInt(PERMISSIONS.CHANGEOWNER) |
+                            BigInt(PERMISSIONS.ADDCONTROLLER) |
+                            BigInt(PERMISSIONS.CALL) |
+                            BigInt(PERMISSIONS.SETDATA),
+                        32,
+                    ),
+                    'LSP6PermissionName',
+                ),
+            ),
+        ).to.deep.equal(expectedPermissions);
+    });
+
+    it('should throw, if LSP6 permission does not exist when testing return value as `LSP6PermissionName[]`', () => {
+        const nonLSP6Permission = BigInt(1) << BigInt(100);
+
+        expect(() =>
+            Array.from(
+                decodePermissions(
+                    toBeHex(
+                        BigInt(PERMISSIONS.CHANGEOWNER) |
+                            BigInt(PERMISSIONS.ADDCONTROLLER) |
+                            BigInt(PERMISSIONS.CALL) |
+                            BigInt(PERMISSIONS.SETDATA) |
+                            nonLSP6Permission,
+                        32,
+                    ),
+                    'LSP6PermissionName',
+                ),
+            ),
+        ).to.throw(`LSP6 permission does not exist. Permission: ${toBeHex(nonLSP6Permission, 32)}`);
+    });
+
+    it('should pass, testing default return value', () => {
+        const expectedPermissions = ['CHANGEOWNER', 'ADDCONTROLLER', 'CALL', 'SETDATA'];
+
+        expect(
+            Array.from(
+                decodePermissions(
+                    toBeHex(
+                        BigInt(PERMISSIONS.CHANGEOWNER) |
+                            BigInt(PERMISSIONS.ADDCONTROLLER) |
+                            BigInt(PERMISSIONS.CALL) |
+                            BigInt(PERMISSIONS.SETDATA),
+                        32,
+                    ),
+                    'LSP6PermissionName',
+                ),
+            ),
+        ).to.deep.equal(expectedPermissions);
+    });
+});


### PR DESCRIPTION
# What does this PR introduce?

This PR introduces a new utility function named `decodePermissions(...)` that allows you to decode a `BitArray` of permissions into different array types:
- 32 bytes hex value
- bigint
- boolean
- LSP6 Permission names