### PR TITLE
refactor: allow generating mappings from `BytesLike`

### DIFF
--- a/src/LSP2/generateMappingKey.ts
+++ b/src/LSP2/generateMappingKey.ts
@@ -1,4 +1,4 @@
-import { concat, isHexString, keccak256, toUtf8Bytes } from 'ethers';
+import { BytesLike, concat, isHexString, keccak256, toUtf8Bytes } from 'ethers';
 
 /**
  * Generates a data key of `{ "keyType": "Mapping" }` that map `firstPart` to `lastPart`.
@@ -36,13 +36,15 @@ import { concat, isHexString, keccak256, toUtf8Bytes } from 'ethers';
  * - generateMappingKey(bytes10Value, bytes20value)
  * //=>`<bytes10Value>:<0000>:<bytes20value>`
  */
-export const generateMappingKey = (firstPart: string, lastPart: string) => {
+export const generateMappingKey = (firstPart: string | BytesLike, lastPart: string | BytesLike) => {
     let firstPartHex = firstPart;
 
     if (!isHexString(firstPart, 10)) {
-        if (isHexString(firstPart)) {
+        if (isHexString(firstPart, 12) && firstPart.endsWith('0000')) {
+            firstPartHex = firstPart.substring(0, 22);
+        } else if (isHexString(firstPart)) {
             firstPartHex = keccak256(firstPart).substring(0, 22);
-        } else {
+        } else if (typeof firstPart === 'string') {
             firstPartHex = keccak256(toUtf8Bytes(firstPart)).substring(0, 22);
         }
     }
@@ -52,7 +54,7 @@ export const generateMappingKey = (firstPart: string, lastPart: string) => {
     if (!isHexString(lastPart, 20)) {
         if (isHexString(lastPart)) {
             lastPartHex = keccak256(lastPart).substring(0, 42);
-        } else {
+        } else if (typeof lastPart === 'string') {
             lastPartHex = keccak256(toUtf8Bytes(lastPart)).substring(0, 42);
         }
     }

--- a/src/LSP2/generateMappingWithGroupingKey.ts
+++ b/src/LSP2/generateMappingWithGroupingKey.ts
@@ -1,4 +1,4 @@
-import { concat, isHexString, keccak256, toUtf8Bytes } from 'ethers';
+import { BytesLike, concat, isHexString, keccak256, toUtf8Bytes } from 'ethers';
 
 /**
  * Generates a data key of `{ "keyType": "MappingWithGrouping" }` that map `firstPart` to `middlePart` and to `lastPart`.
@@ -55,16 +55,16 @@ import { concat, isHexString, keccak256, toUtf8Bytes } from 'ethers';
  * //=> `<bytes6Value>:<bytes4Value>:<0000>:<bytes20Value>`
  */
 export const generateMappingWithGroupingKey = (
-    firstPart: string,
-    middlePart: string,
-    lastPart: string,
+    firstPart: string | BytesLike,
+    middlePart: string | BytesLike,
+    lastPart: string | BytesLike,
 ) => {
     let firstPartHex = firstPart;
 
     if (!isHexString(firstPart, 6)) {
         if (isHexString(firstPart)) {
             firstPartHex = keccak256(firstPart).substring(0, 14);
-        } else {
+        } else if (typeof firstPart === 'string') {
             firstPartHex = keccak256(toUtf8Bytes(firstPart)).substring(0, 14);
         }
     }
@@ -74,7 +74,7 @@ export const generateMappingWithGroupingKey = (
     if (!isHexString(middlePart, 4)) {
         if (isHexString(middlePart)) {
             middlePartHex = keccak256(middlePart).substring(0, 10);
-        } else {
+        } else if (typeof middlePart === 'string') {
             middlePartHex = keccak256(toUtf8Bytes(middlePart)).substring(0, 10);
         }
     }
@@ -84,7 +84,7 @@ export const generateMappingWithGroupingKey = (
     if (!isHexString(lastPart, 20)) {
         if (isHexString(lastPart)) {
             lastPartHex = keccak256(lastPart).substring(0, 42);
-        } else {
+        } else if (typeof lastPart === 'string') {
             lastPartHex = keccak256(toUtf8Bytes(lastPart)).substring(0, 42);
         }
     }


### PR DESCRIPTION
# What does this PR introduce?

This PR allows using `BytesLike` values in:
- `generateMappingKey.ts`
- `generateMappingWithGroupingKey.ts`