### PR TITLE
chore: change library name

### DIFF
--- a/.versionrc.json
+++ b/.versionrc.json
@@ -33,6 +33,6 @@
             "hidden": true
         }
     ],
-    "commitUrlFormat": "https://github.com/lukso-network/lsp-smart-contracts-utils/commits/{{hash}}",
-    "compareUrlFormat": "https://github.com/lukso-network/lsp-smart-contracts-utils/compare/{{previousTag}}...{{currentTag}}"
+    "commitUrlFormat": "https://github.com/lukso-network/lsp-utils/commits/{{hash}}",
+    "compareUrlFormat": "https://github.com/lukso-network/lsp-utils/compare/{{previousTag}}...{{currentTag}}"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [0.0.2](https://github.com/lukso-network/lsp-smart-contracts-utils/compare/v0.0.1...v0.0.2) (2023-10-15)
+### [0.0.2](https://github.com/lukso-network/lsp-utils/compare/v0.0.1...v0.0.2) (2023-10-15)
 
 ### Features
 
--   add `AllowedCalls` utils ([53eb309](https://github.com/lukso-network/lsp-smart-contracts-utils/commits/53eb309538477251b8751cbecebd4bf96a71f784))
--   add `AllowedERC725YDataKeys` utils ([4b929a4](https://github.com/lukso-network/lsp-smart-contracts-utils/commits/4b929a497ca05a3803deadbcedce788b9834be08))
--   add `validityTimestamp` util function ([3ecb48a](https://github.com/lukso-network/lsp-smart-contracts-utils/commits/3ecb48aa8202a5f41cbab8d3cd1d70f53065aab2))
--   export constants ([87f3dd2](https://github.com/lukso-network/lsp-smart-contracts-utils/commits/87f3dd2e9357a4bfb98a7351db94013b9b12afd4))
+-   add `AllowedCalls` utils ([53eb309](https://github.com/lukso-network/lsp-utils/commits/53eb309538477251b8751cbecebd4bf96a71f784))
+-   add `AllowedERC725YDataKeys` utils ([4b929a4](https://github.com/lukso-network/lsp-utils/commits/4b929a497ca05a3803deadbcedce788b9834be08))
+-   add `validityTimestamp` util function ([3ecb48a](https://github.com/lukso-network/lsp-utils/commits/3ecb48aa8202a5f41cbab8d3cd1d70f53065aab2))
+-   export constants ([87f3dd2](https://github.com/lukso-network/lsp-utils/commits/87f3dd2e9357a4bfb98a7351db94013b9b12afd4))
 
 ### 0.0.1 (2023-10-15)
 
 ### Features
 
--   create initial lib ([a15b1a4](https://github.com/lukso-network/lsp-smart-contracts-utils/commits/a15b1a4ebff3c53dc18c85fecceb3ff35e918309))
+-   create initial lib ([a15b1a4](https://github.com/lukso-network/lsp-utils/commits/a15b1a4ebff3c53dc18c85fecceb3ff35e918309))

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LSP Smart Contracts Utils &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp-smart-contracts-utils.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp-smart-contracts-utils)
+# LSP Smart Contracts Utils &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp-utils.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp-utils)
 
 This package was created with the intent to help developers to use `@lukso/lsp-smart-contracts`. Its purpose is to provide a series of helper functions for each LSP.
 
@@ -12,10 +12,10 @@ This package was created with the intent to help developers to use `@lukso/lsp-s
 
 ### npm
 
-`@lukso/lsp-smart-contracts-utils` is available as a [npm package](https://www.npmjs.com/package/@lukso/lsp-smart-contracts-utils).
+`@lukso/lsp-utils` is available as a [npm package](https://www.npmjs.com/package/@lukso/lsp-utils).
 
 ```bash
-npm install @lukso/lsp-smart-contracts-utils
+npm install @lukso/lsp-utils
 ```
 
 ### cloning the repository
@@ -23,8 +23,8 @@ npm install @lukso/lsp-smart-contracts-utils
 Alternatively you can also clone the repository and install its dependencies to start using the smart contracts.
 
 ```bash
-$ git clone https://github.com/lukso-network/lsp-smart-contracts-utils.git
-$ cd ./lsp-smart-contracts-utils
+$ git clone https://github.com/lukso-network/lsp-utils.git
+$ cd ./lsp-utils
 $ npm install
 ```
 
@@ -37,7 +37,7 @@ You can use the utils by importing them as follow:
 #### ES6 Modules:
 
 ```javascript
-import { encodeAllowedCalls } from '@lukso/lsp-smart-contracts-utils/dist/lib/es6';
+import { encodeAllowedCalls } from '@lukso/lsp-utils/dist/lib/es6';
 
 const allowedCalls = encodeAllowedCalls(
     allowedInteractions,
@@ -50,7 +50,7 @@ const allowedCalls = encodeAllowedCalls(
 #### CommonJS
 
 ```javascript
-cosnt { encodeAllowedCalls } = require('@lukso/lsp-smart-contracts-utils/dist/lib/es5');
+cosnt { encodeAllowedCalls } = require('@lukso/lsp-utils/dist/lib/es5');
 
 const allowedCalls = encodeAllowedCalls(
     allowedInteractions,

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# LSP Smart Contracts Utils &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp-smart-contracts-utils.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp-smart-contracts-utils)
+# LSP Smart Contracts Utils &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp-utils.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp-utils)
 
 This package was created with the intent to help developers to use `@lukso/lsp-smart-contracts`. Its purpose is to provide a series of helper functions for each LSP.
 
@@ -12,10 +12,10 @@ This package was created with the intent to help developers to use `@lukso/lsp-s
 
 ### npm
 
-`@lukso/lsp-smart-contracts-utils` is available as a [npm package](https://www.npmjs.com/package/@lukso/lsp-smart-contracts-utils).
+`@lukso/lsp-utils` is available as a [npm package](https://www.npmjs.com/package/@lukso/lsp-utils).
 
 ```bash
-npm install @lukso/lsp-smart-contracts-utils
+npm install @lukso/lsp-utils
 ```
 
 ### cloning the repository
@@ -23,8 +23,8 @@ npm install @lukso/lsp-smart-contracts-utils
 Alternatively you can also clone the repository and install its dependencies to start using the smart contracts.
 
 ```bash
-$ git clone https://github.com/lukso-network/lsp-smart-contracts-utils.git
-$ cd ./lsp-smart-contracts-utils
+$ git clone https://github.com/lukso-network/lsp-utils.git
+$ cd ./lsp-utils
 $ npm install
 ```
 
@@ -37,7 +37,7 @@ You can use the utils by importing them as follow:
 #### ES6 Modules:
 
 ```javascript
-import { encodeAllowedCalls } from '@lukso/lsp-smart-contracts-utils/dist/lib/es6';
+import { encodeAllowedCalls } from '@lukso/lsp-utils/dist/lib/es6';
 
 const allowedCalls = encodeAllowedCalls(
     allowedInteractions,
@@ -50,7 +50,7 @@ const allowedCalls = encodeAllowedCalls(
 #### CommonJS
 
 ```javascript
-cosnt { encodeAllowedCalls } = require('@lukso/lsp-smart-contracts-utils/dist/lib/es5');
+cosnt { encodeAllowedCalls } = require('@lukso/lsp-utils/dist/lib/es5');
 
 const allowedCalls = encodeAllowedCalls(
     allowedInteractions,

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,11 +1,11 @@
-# @lukso/lsp-smart-contracts-utils
+# @lukso/lsp-utils
 
 ## Modules
 
-- [IPFS](modules/IPFS.md)
-- [LSP12](modules/LSP12.md)
-- [LSP2](modules/LSP2.md)
-- [LSP3](modules/LSP3.md)
-- [LSP4](modules/LSP4.md)
-- [LSP5](modules/LSP5.md)
-- [LSP6](modules/LSP6.md)
+-   [IPFS](modules/IPFS.md)
+-   [LSP12](modules/LSP12.md)
+-   [LSP2](modules/LSP2.md)
+-   [LSP3](modules/LSP3.md)
+-   [LSP4](modules/LSP4.md)
+-   [LSP5](modules/LSP5.md)
+-   [LSP6](modules/LSP6.md)

--- a/docs/modules/IPFS.md
+++ b/docs/modules/IPFS.md
@@ -33,4 +33,4 @@ validateIpfsUrl(''); //=> ''
 
 #### Defined in
 
-[IPFS/validateIpfsUrl/validateIpfsUrl.ts:15](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/IPFS/validateIpfsUrl/validateIpfsUrl.ts#L15)
+[IPFS/validateIpfsUrl/validateIpfsUrl.ts:15](https://github.com/lukso-network/lsp-utils/blob/main/src/IPFS/validateIpfsUrl/validateIpfsUrl.ts#L15)

--- a/docs/modules/LSP12.md
+++ b/docs/modules/LSP12.md
@@ -35,7 +35,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-12-IssuedAssets.md
 
 #### Defined in
 
-[LSP12/addIssuedAssets/addIssuedAssets.ts:36](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP12/addIssuedAssets/addIssuedAssets.ts#L36)
+[LSP12/addIssuedAssets/addIssuedAssets.ts:36](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP12/addIssuedAssets/addIssuedAssets.ts#L36)
 
 ▸ **addIssuedAssets**(`issuer`, `newIssuedAssets`, `signer`): `Promise`\<`void`\>
 
@@ -53,7 +53,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-12-IssuedAssets.md
 
 #### Defined in
 
-[LSP12/addIssuedAssets/addIssuedAssets.ts:40](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP12/addIssuedAssets/addIssuedAssets.ts#L40)
+[LSP12/addIssuedAssets/addIssuedAssets.ts:40](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP12/addIssuedAssets/addIssuedAssets.ts#L40)
 
 ▸ **addIssuedAssets**(`issuer`, `newIssuedAssets`, `signer`): `Promise`\<`void`\>
 
@@ -71,7 +71,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-12-IssuedAssets.md
 
 #### Defined in
 
-[LSP12/addIssuedAssets/addIssuedAssets.ts:45](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP12/addIssuedAssets/addIssuedAssets.ts#L45)
+[LSP12/addIssuedAssets/addIssuedAssets.ts:45](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP12/addIssuedAssets/addIssuedAssets.ts#L45)
 
 ---
 
@@ -109,7 +109,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-12-IssuedAssets.md
 
 #### Defined in
 
-[LSP12/getIssuedAssets/getIssuedAssets.ts:32](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP12/getIssuedAssets/getIssuedAssets.ts#L32)
+[LSP12/getIssuedAssets/getIssuedAssets.ts:32](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP12/getIssuedAssets/getIssuedAssets.ts#L32)
 
 ▸ **getIssuedAssets**(`issuer`, `provider`): `Promise`\<`DigitalAsset`[]\>
 
@@ -126,7 +126,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-12-IssuedAssets.md
 
 #### Defined in
 
-[LSP12/getIssuedAssets/getIssuedAssets.ts:33](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP12/getIssuedAssets/getIssuedAssets.ts#L33)
+[LSP12/getIssuedAssets/getIssuedAssets.ts:33](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP12/getIssuedAssets/getIssuedAssets.ts#L33)
 
 ▸ **getIssuedAssets**(`issuer`, `provider`): `Promise`\<`DigitalAsset`[]\>
 
@@ -143,7 +143,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-12-IssuedAssets.md
 
 #### Defined in
 
-[LSP12/getIssuedAssets/getIssuedAssets.ts:34](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP12/getIssuedAssets/getIssuedAssets.ts#L34)
+[LSP12/getIssuedAssets/getIssuedAssets.ts:34](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP12/getIssuedAssets/getIssuedAssets.ts#L34)
 
 ---
 
@@ -180,7 +180,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-12-IssuedAssets.md
 
 #### Defined in
 
-[LSP12/removeIssuedAssets/removeIssuedAssets.ts:27](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP12/removeIssuedAssets/removeIssuedAssets.ts#L27)
+[LSP12/removeIssuedAssets/removeIssuedAssets.ts:27](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP12/removeIssuedAssets/removeIssuedAssets.ts#L27)
 
 ▸ **removeIssuedAssets**(`issuer`, `signer`): `Promise`\<`void`\>
 
@@ -197,7 +197,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-12-IssuedAssets.md
 
 #### Defined in
 
-[LSP12/removeIssuedAssets/removeIssuedAssets.ts:28](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP12/removeIssuedAssets/removeIssuedAssets.ts#L28)
+[LSP12/removeIssuedAssets/removeIssuedAssets.ts:28](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP12/removeIssuedAssets/removeIssuedAssets.ts#L28)
 
 ▸ **removeIssuedAssets**(`issuer`, `signer`): `Promise`\<`void`\>
 
@@ -214,4 +214,4 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-12-IssuedAssets.md
 
 #### Defined in
 
-[LSP12/removeIssuedAssets/removeIssuedAssets.ts:29](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP12/removeIssuedAssets/removeIssuedAssets.ts#L29)
+[LSP12/removeIssuedAssets/removeIssuedAssets.ts:29](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP12/removeIssuedAssets/removeIssuedAssets.ts#L29)

--- a/docs/modules/LSP2.md
+++ b/docs/modules/LSP2.md
@@ -60,7 +60,7 @@ decodeAssetUrl("0x6f357c6a2a04850096912391bbb0966a624519e8f5d797df2a2c47425e892c
 
 #### Defined in
 
-[LSP2/decodeAssetUrl/decodeAssetUrl.ts:35](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP2/decodeAssetUrl/decodeAssetUrl.ts#L35)
+[LSP2/decodeAssetUrl/decodeAssetUrl.ts:35](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP2/decodeAssetUrl/decodeAssetUrl.ts#L35)
 
 ---
 
@@ -122,7 +122,7 @@ decodeJsonUrl("0x6f357c6a4dade694d7dd4081f46073e99ce898a9b53cf6988452904de7db5cc
 
 #### Defined in
 
-[LSP2/decodeJsonUrl/decodeJsonUrl.ts:35](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP2/decodeJsonUrl/decodeJsonUrl.ts#L35)
+[LSP2/decodeJsonUrl/decodeJsonUrl.ts:35](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP2/decodeJsonUrl/decodeJsonUrl.ts#L35)
 
 ---
 
@@ -166,7 +166,7 @@ encodeAssetUrl(
 
 #### Defined in
 
-[LSP2/encodeAssetUrl/encodeAssetUrl.ts:23](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP2/encodeAssetUrl/encodeAssetUrl.ts#L23)
+[LSP2/encodeAssetUrl/encodeAssetUrl.ts:23](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP2/encodeAssetUrl/encodeAssetUrl.ts#L23)
 
 ---
 
@@ -210,7 +210,7 @@ encodeJsonUrl(
 
 #### Defined in
 
-[LSP2/encodeJsonUrl/encodeJsonUrl.ts:23](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP2/encodeJsonUrl/encodeJsonUrl.ts#L23)
+[LSP2/encodeJsonUrl/encodeJsonUrl.ts:23](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP2/encodeJsonUrl/encodeJsonUrl.ts#L23)
 
 ---
 
@@ -253,7 +253,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md
 
 #### Defined in
 
-[LSP2/generateArrayElementKeyAtIndex/generateArrayElementKeyAtIndex.ts:22](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP2/generateArrayElementKeyAtIndex/generateArrayElementKeyAtIndex.ts#L22)
+[LSP2/generateArrayElementKeyAtIndex/generateArrayElementKeyAtIndex.ts:22](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP2/generateArrayElementKeyAtIndex/generateArrayElementKeyAtIndex.ts#L22)
 
 ---
 
@@ -299,7 +299,7 @@ generateArrayKey('RandomArrayDataKey[]'); //=> keccak256("RandomArrayDataKey[]")
 
 #### Defined in
 
-[LSP2/generateArrayKey/generateArrayKey.ts:20](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP2/generateArrayKey/generateArrayKey.ts#L20)
+[LSP2/generateArrayKey/generateArrayKey.ts:20](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP2/generateArrayKey/generateArrayKey.ts#L20)
 
 ---
 
@@ -361,7 +361,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md
 
 #### Defined in
 
-[LSP2/generateMappingKey/generateMappingKey.ts:39](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP2/generateMappingKey/generateMappingKey.ts#L39)
+[LSP2/generateMappingKey/generateMappingKey.ts:39](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP2/generateMappingKey/generateMappingKey.ts#L39)
 
 ---
 
@@ -442,7 +442,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md
 
 #### Defined in
 
-[LSP2/generateMappingWithGroupingKey/generateMappingWithGroupingKey.ts:57](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP2/generateMappingWithGroupingKey/generateMappingWithGroupingKey.ts#L57)
+[LSP2/generateMappingWithGroupingKey/generateMappingWithGroupingKey.ts:57](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP2/generateMappingWithGroupingKey/generateMappingWithGroupingKey.ts#L57)
 
 ---
 
@@ -480,7 +480,7 @@ generateSingletonKey('RandomDataKey'); //=> keccak256("RandomKeyName") = "0xb0c9
 
 #### Defined in
 
-[LSP2/generateSingletonKey/generateSingletonKey.ts:17](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP2/generateSingletonKey/generateSingletonKey.ts#L17)
+[LSP2/generateSingletonKey/generateSingletonKey.ts:17](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP2/generateSingletonKey/generateSingletonKey.ts#L17)
 
 ---
 
@@ -520,7 +520,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md
 
 #### Defined in
 
-[LSP2/isCompactBytesArray/isCompactBytesArray.ts:19](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP2/isCompactBytesArray/isCompactBytesArray.ts#L19)
+[LSP2/isCompactBytesArray/isCompactBytesArray.ts:19](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP2/isCompactBytesArray/isCompactBytesArray.ts#L19)
 
 ---
 
@@ -561,7 +561,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md
 
 #### Defined in
 
-[LSP2/isValidArrayLengthValue/isValidArrayLengthValue.ts:20](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP2/isValidArrayLengthValue/isValidArrayLengthValue.ts#L20)
+[LSP2/isValidArrayLengthValue/isValidArrayLengthValue.ts:20](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP2/isValidArrayLengthValue/isValidArrayLengthValue.ts#L20)
 
 ---
 
@@ -604,7 +604,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md
 
 #### Defined in
 
-[LSP2/removeElementFromArrayAndMap/removeElementFromArrayAndMap.ts:28](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP2/removeElementFromArrayAndMap/removeElementFromArrayAndMap.ts#L28)
+[LSP2/removeElementFromArrayAndMap/removeElementFromArrayAndMap.ts:28](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP2/removeElementFromArrayAndMap/removeElementFromArrayAndMap.ts#L28)
 
 ---
 
@@ -650,4 +650,4 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md
 
 #### Defined in
 
-[LSP2/removeLastElementFromArrayAndMap/removeLastElementFromArrayAndMap.ts:20](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP2/removeLastElementFromArrayAndMap/removeLastElementFromArrayAndMap.ts#L20)
+[LSP2/removeLastElementFromArrayAndMap/removeLastElementFromArrayAndMap.ts:20](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP2/removeLastElementFromArrayAndMap/removeLastElementFromArrayAndMap.ts#L20)

--- a/docs/modules/LSP3.md
+++ b/docs/modules/LSP3.md
@@ -46,7 +46,7 @@ getMetadata(UniversalProfile) //=>
 
 #### Defined in
 
-[LSP3/getProfileMetadata/getProfileMetadata.ts:44](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP3/getProfileMetadata/getProfileMetadata.ts#L44)
+[LSP3/getProfileMetadata/getProfileMetadata.ts:44](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP3/getProfileMetadata/getProfileMetadata.ts#L44)
 
 ▸ **getProfileMetadata**(`unviersalProfile`, `provider`): `Promise`\<`LSP3ProfileMetadata`\>
 
@@ -63,7 +63,7 @@ getMetadata(UniversalProfile) //=>
 
 #### Defined in
 
-[LSP3/getProfileMetadata/getProfileMetadata.ts:47](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP3/getProfileMetadata/getProfileMetadata.ts#L47)
+[LSP3/getProfileMetadata/getProfileMetadata.ts:47](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP3/getProfileMetadata/getProfileMetadata.ts#L47)
 
 ---
 
@@ -100,4 +100,4 @@ isProfileMetadata({ description: "", links: [], name: "", tags: [] }) //=> false
 
 #### Defined in
 
-[LSP3/isProfileMetadata/isProfileMetadata.ts:16](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP3/isProfileMetadata/isProfileMetadata.ts#L16)
+[LSP3/isProfileMetadata/isProfileMetadata.ts:16](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP3/isProfileMetadata/isProfileMetadata.ts#L16)

--- a/docs/modules/LSP4.md
+++ b/docs/modules/LSP4.md
@@ -35,7 +35,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata
 
 #### Defined in
 
-[LSP4/addDigitalAssetCreators/addDigitalAssetCreators.ts:36](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP4/addDigitalAssetCreators/addDigitalAssetCreators.ts#L36)
+[LSP4/addDigitalAssetCreators/addDigitalAssetCreators.ts:36](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP4/addDigitalAssetCreators/addDigitalAssetCreators.ts#L36)
 
 ▸ **addDigitalAssetCreators**(`digitalAsset`, `newCreators`, `signer`): `Promise`\<`void`\>
 
@@ -53,7 +53,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata
 
 #### Defined in
 
-[LSP4/addDigitalAssetCreators/addDigitalAssetCreators.ts:40](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP4/addDigitalAssetCreators/addDigitalAssetCreators.ts#L40)
+[LSP4/addDigitalAssetCreators/addDigitalAssetCreators.ts:40](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP4/addDigitalAssetCreators/addDigitalAssetCreators.ts#L40)
 
 ▸ **addDigitalAssetCreators**(`digitalAsset`, `newCreators`, `signer`): `Promise`\<`void`\>
 
@@ -71,7 +71,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata
 
 #### Defined in
 
-[LSP4/addDigitalAssetCreators/addDigitalAssetCreators.ts:45](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP4/addDigitalAssetCreators/addDigitalAssetCreators.ts#L45)
+[LSP4/addDigitalAssetCreators/addDigitalAssetCreators.ts:45](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP4/addDigitalAssetCreators/addDigitalAssetCreators.ts#L45)
 
 ---
 
@@ -109,7 +109,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata
 
 #### Defined in
 
-[LSP4/getDigitalAssetCreators/getDigitalAssetCreators.ts:32](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP4/getDigitalAssetCreators/getDigitalAssetCreators.ts#L32)
+[LSP4/getDigitalAssetCreators/getDigitalAssetCreators.ts:32](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP4/getDigitalAssetCreators/getDigitalAssetCreators.ts#L32)
 
 ▸ **getDigitalAssetCreators**(`digitalAsset`, `provider`): `Promise`\<`Issuer`[]\>
 
@@ -126,7 +126,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata
 
 #### Defined in
 
-[LSP4/getDigitalAssetCreators/getDigitalAssetCreators.ts:33](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP4/getDigitalAssetCreators/getDigitalAssetCreators.ts#L33)
+[LSP4/getDigitalAssetCreators/getDigitalAssetCreators.ts:33](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP4/getDigitalAssetCreators/getDigitalAssetCreators.ts#L33)
 
 ▸ **getDigitalAssetCreators**(`digitalAsset`, `provider`): `Promise`\<`Issuer`[]\>
 
@@ -143,7 +143,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata
 
 #### Defined in
 
-[LSP4/getDigitalAssetCreators/getDigitalAssetCreators.ts:37](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP4/getDigitalAssetCreators/getDigitalAssetCreators.ts#L37)
+[LSP4/getDigitalAssetCreators/getDigitalAssetCreators.ts:37](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP4/getDigitalAssetCreators/getDigitalAssetCreators.ts#L37)
 
 ---
 
@@ -180,7 +180,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata
 
 #### Defined in
 
-[LSP4/removeDigitalAssetCreators/removeDigitalAssetCreators.ts:27](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP4/removeDigitalAssetCreators/removeDigitalAssetCreators.ts#L27)
+[LSP4/removeDigitalAssetCreators/removeDigitalAssetCreators.ts:27](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP4/removeDigitalAssetCreators/removeDigitalAssetCreators.ts#L27)
 
 ▸ **removeDigitalAssetCreators**(`digitalAsset`, `provider`): `Promise`\<`void`\>
 
@@ -197,7 +197,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata
 
 #### Defined in
 
-[LSP4/removeDigitalAssetCreators/removeDigitalAssetCreators.ts:28](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP4/removeDigitalAssetCreators/removeDigitalAssetCreators.ts#L28)
+[LSP4/removeDigitalAssetCreators/removeDigitalAssetCreators.ts:28](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP4/removeDigitalAssetCreators/removeDigitalAssetCreators.ts#L28)
 
 ▸ **removeDigitalAssetCreators**(`digitalAsset`, `provider`): `Promise`\<`void`\>
 
@@ -214,4 +214,4 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata
 
 #### Defined in
 
-[LSP4/removeDigitalAssetCreators/removeDigitalAssetCreators.ts:32](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP4/removeDigitalAssetCreators/removeDigitalAssetCreators.ts#L32)
+[LSP4/removeDigitalAssetCreators/removeDigitalAssetCreators.ts:32](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP4/removeDigitalAssetCreators/removeDigitalAssetCreators.ts#L32)

--- a/docs/modules/LSP5.md
+++ b/docs/modules/LSP5.md
@@ -38,7 +38,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-5-ReceivedAssets.md
 
 #### Defined in
 
-[LSP5/generateReceivedAssetKeys/generateReceivedAssetKeys.ts:30](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP5/generateReceivedAssetKeys/generateReceivedAssetKeys.ts#L30)
+[LSP5/generateReceivedAssetKeys/generateReceivedAssetKeys.ts:30](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP5/generateReceivedAssetKeys/generateReceivedAssetKeys.ts#L30)
 
 ---
 
@@ -77,4 +77,4 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-5-ReceivedAssets.md
 
 #### Defined in
 
-[LSP5/generateSentAssetKeys/generateSentAssetKeys.ts:32](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP5/generateSentAssetKeys/generateSentAssetKeys.ts#L32)
+[LSP5/generateSentAssetKeys/generateSentAssetKeys.ts:32](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP5/generateSentAssetKeys/generateSentAssetKeys.ts#L32)

--- a/docs/modules/LSP6.md
+++ b/docs/modules/LSP6.md
@@ -41,7 +41,7 @@ createValidityTimestamp(5, 10) //=> `0x00000000000000000000000000000005000000000
 
 #### Defined in
 
-[LSP6/createValidityTimestamp/createValidityTimestamp.ts:21](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP6/createValidityTimestamp/createValidityTimestamp.ts#L21)
+[LSP6/createValidityTimestamp/createValidityTimestamp.ts:21](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP6/createValidityTimestamp/createValidityTimestamp.ts#L21)
 
 ---
 
@@ -106,7 +106,7 @@ decodeAllowedCalls("0x002000000002cafecafecafecafecafecafecafecafecafecafe24871b
 
 #### Defined in
 
-[LSP6/decodeAllowedCalls/decodeAllowedCalls.ts:37](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP6/decodeAllowedCalls/decodeAllowedCalls.ts#L37)
+[LSP6/decodeAllowedCalls/decodeAllowedCalls.ts:37](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP6/decodeAllowedCalls/decodeAllowedCalls.ts#L37)
 
 ---
 
@@ -154,7 +154,7 @@ decodeAllowedERC725YDataKeys("0x0002cafe000abeefdeadbeef0000cafe") //=>
 
 #### Defined in
 
-[LSP6/decodeAllowedERC725YDataKeys/decodeAllowedERC725YDataKeys.ts:27](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP6/decodeAllowedERC725YDataKeys/decodeAllowedERC725YDataKeys.ts#L27)
+[LSP6/decodeAllowedERC725YDataKeys/decodeAllowedERC725YDataKeys.ts:27](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP6/decodeAllowedERC725YDataKeys/decodeAllowedERC725YDataKeys.ts#L27)
 
 ---
 
@@ -218,7 +218,7 @@ decodePermissions([
 
 #### Defined in
 
-[LSP6/decodePermissions/decodePermissions.ts:53](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP6/decodePermissions/decodePermissions.ts#L53)
+[LSP6/decodePermissions/decodePermissions.ts:53](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP6/decodePermissions/decodePermissions.ts#L53)
 
 ▸ **decodePermissions**(`permissions`, `decodedPermissionsType`): `Set`\<`BytesLike`\>
 
@@ -235,7 +235,7 @@ decodePermissions([
 
 #### Defined in
 
-[LSP6/decodePermissions/decodePermissions.ts:54](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP6/decodePermissions/decodePermissions.ts#L54)
+[LSP6/decodePermissions/decodePermissions.ts:54](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP6/decodePermissions/decodePermissions.ts#L54)
 
 ▸ **decodePermissions**(`permissions`, `decodedPermissionsType`): `Set`\<`bigint`\>
 
@@ -252,7 +252,7 @@ decodePermissions([
 
 #### Defined in
 
-[LSP6/decodePermissions/decodePermissions.ts:58](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP6/decodePermissions/decodePermissions.ts#L58)
+[LSP6/decodePermissions/decodePermissions.ts:58](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP6/decodePermissions/decodePermissions.ts#L58)
 
 ▸ **decodePermissions**(`permissions`, `decodedPermissionsType`): `boolean`[]
 
@@ -269,7 +269,7 @@ decodePermissions([
 
 #### Defined in
 
-[LSP6/decodePermissions/decodePermissions.ts:62](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP6/decodePermissions/decodePermissions.ts#L62)
+[LSP6/decodePermissions/decodePermissions.ts:62](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP6/decodePermissions/decodePermissions.ts#L62)
 
 ▸ **decodePermissions**(`permissions`, `decodedPermissionsType`): `Set`\<`LSP6PermissionName`\>
 
@@ -286,7 +286,7 @@ decodePermissions([
 
 #### Defined in
 
-[LSP6/decodePermissions/decodePermissions.ts:66](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP6/decodePermissions/decodePermissions.ts#L66)
+[LSP6/decodePermissions/decodePermissions.ts:66](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP6/decodePermissions/decodePermissions.ts#L66)
 
 ---
 
@@ -346,7 +346,7 @@ encodeAllowedCalls(
 
 #### Defined in
 
-[LSP6/encodeAllowedCalls/encodeAllowedCalls.ts:39](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP6/encodeAllowedCalls/encodeAllowedCalls.ts#L39)
+[LSP6/encodeAllowedCalls/encodeAllowedCalls.ts:39](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP6/encodeAllowedCalls/encodeAllowedCalls.ts#L39)
 
 ---
 
@@ -392,7 +392,7 @@ encodeAllowedERC725YDataKeys([
 
 #### Defined in
 
-[LSP6/encodeAllowedERC725YDataKeys/encodeAllowedERC725YDataKeys.ts:25](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP6/encodeAllowedERC725YDataKeys/encodeAllowedERC725YDataKeys.ts#L25)
+[LSP6/encodeAllowedERC725YDataKeys/encodeAllowedERC725YDataKeys.ts:25](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP6/encodeAllowedERC725YDataKeys/encodeAllowedERC725YDataKeys.ts#L25)
 
 ---
 
@@ -446,4 +446,4 @@ encodePermissions([
 
 #### Defined in
 
-[LSP6/encodePermissions/encodePermissions.ts:35](https://github.com/lukso-network/lsp-smart-contracts-utils/blob/main/src/LSP6/encodePermissions/encodePermissions.ts#L35)
+[LSP6/encodePermissions/encodePermissions.ts:35](https://github.com/lukso-network/lsp-utils/blob/main/src/LSP6/encodePermissions/encodePermissions.ts#L35)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "@lukso/lsp-smart-contracts-utils",
+    "name": "@lukso/lsp-utils",
     "version": "0.0.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "@lukso/lsp-smart-contracts-utils",
+            "name": "@lukso/lsp-utils",
             "version": "0.0.2",
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-    "name": "@lukso/lsp-smart-contracts-utils",
+    "name": "@lukso/lsp-utils",
     "version": "0.0.2",
     "description": "A set of TypeScript/JavaScript utils for LUKSO Standard Proposals (LSPs)",
     "author": "Daniel Afteni (B00ste)",
     "license": "MIT",
-    "homepage": "https://github.com/lukso-network/lsp-smart-contracts-utils#readme",
+    "homepage": "https://github.com/lukso-network/lsp-utils#readme",
     "bugs": {
-        "url": "https://github.com/lukso-network/lsp-smart-contracts-utils/issues"
+        "url": "https://github.com/lukso-network/lsp-utils/issues"
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/lukso-network/lsp-smart-contracts-utils.git"
+        "url": "git+https://github.com/lukso-network/lsp-utils.git"
     },
     "files": [
         "dist",


### PR DESCRIPTION
# What does this PR introduce?

Changing the library name from `lsp-smart-contracts-utils` to `lsp-utils`.