### PR TITLE
ci: remove unecessary inputs for release-please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,7 @@ jobs:
             - uses: google-github-actions/release-please-action@v4
               id: release
               with:
-                  release-type: node
                   target-branch: main
-                  command: manifest
 
             - uses: actions/checkout@v3
               if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Remove unecessary CI inputs in workflow since upgrade to v4 of the github action. These are now sets via the `.release-please-config.json`