### PR TITLE
feat: add support for latest versions, plus VerifiableURI support

### DIFF
--- a/docs/modules/IPFS.md
+++ b/docs/modules/IPFS.md
@@ -33,4 +33,4 @@ validateIpfsUrl('') => ''
 
 #### Defined in
 
-[IPFS/validateIpfsUrl/validateIpfsUrl.ts:17](https://github.com/lukso-network/lsp-utils/blob/122accb/src/IPFS/validateIpfsUrl/validateIpfsUrl.ts#L17)
+[IPFS/validateIpfsUrl/validateIpfsUrl.ts:17](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/IPFS/validateIpfsUrl/validateIpfsUrl.ts#L17)

--- a/docs/modules/LSP12IssuedAssets.md
+++ b/docs/modules/LSP12IssuedAssets.md
@@ -36,7 +36,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-12-IssuedAssets.md
 
 #### Defined in
 
-LSP12IssuedAssets/addIssuedAssets/addIssuedAssets.ts:32
+[LSP12IssuedAssets/addIssuedAssets/addIssuedAssets.ts:32](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP12IssuedAssets/addIssuedAssets/addIssuedAssets.ts#L32)
 
 ---
 
@@ -73,7 +73,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-12-IssuedAssets.md
 
 #### Defined in
 
-LSP12IssuedAssets/authenticateIssuedAssets/authenticateIssuedAssets.ts:27
+[LSP12IssuedAssets/authenticateIssuedAssets/authenticateIssuedAssets.ts:27](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP12IssuedAssets/authenticateIssuedAssets/authenticateIssuedAssets.ts#L27)
 
 ---
 
@@ -112,7 +112,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-12-IssuedAssets.md
 
 #### Defined in
 
-LSP12IssuedAssets/getIssuedAssets/getIssuedAssets.ts:33
+[LSP12IssuedAssets/getIssuedAssets/getIssuedAssets.ts:33](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP12IssuedAssets/getIssuedAssets/getIssuedAssets.ts#L33)
 
 ---
 
@@ -150,4 +150,4 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-12-IssuedAssets.md
 
 #### Defined in
 
-LSP12IssuedAssets/removeIssuedAssets/removeIssuedAssets.ts:27
+[LSP12IssuedAssets/removeIssuedAssets/removeIssuedAssets.ts:27](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP12IssuedAssets/removeIssuedAssets/removeIssuedAssets.ts#L27)

--- a/docs/modules/LSP23LinkedContractsFactory.md
+++ b/docs/modules/LSP23LinkedContractsFactory.md
@@ -31,4 +31,4 @@ v0.0.2
 
 #### Defined in
 
-LSP23LinkedContractsFactory/deployUniversalProfile/deployUniversalProfile.ts:34
+[LSP23LinkedContractsFactory/deployUniversalProfile/deployUniversalProfile.ts:34](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP23LinkedContractsFactory/deployUniversalProfile/deployUniversalProfile.ts#L34)

--- a/docs/modules/LSP2ERC725YJSONSchema.md
+++ b/docs/modules/LSP2ERC725YJSONSchema.md
@@ -60,7 +60,7 @@ decodeAssetUrl("0x6f357c6a2a04850096912391bbb0966a624519e8f5d797df2a2c47425e892c
 
 #### Defined in
 
-LSP2ERC725YJSONSchema/decodeAssetUrl/decodeAssetUrl.ts:35
+[LSP2ERC725YJSONSchema/decodeAssetUrl/decodeAssetUrl.ts:35](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP2ERC725YJSONSchema/decodeAssetUrl/decodeAssetUrl.ts#L35)
 
 ---
 
@@ -122,7 +122,46 @@ decodeJsonUrl("0x6f357c6a4dade694d7dd4081f46073e99ce898a9b53cf6988452904de7db5cc
 
 #### Defined in
 
-LSP2ERC725YJSONSchema/decodeJsonUrl/decodeJsonUrl.ts:35
+[LSP2ERC725YJSONSchema/decodeJsonUrl/decodeJsonUrl.ts:35](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP2ERC725YJSONSchema/decodeJsonUrl/decodeJsonUrl.ts#L35)
+
+---
+
+### decodeVerifiableURI
+
+▸ **decodeVerifiableURI**(`data`): `string` \| `number` \| `boolean` \| `URLDataWithHash`
+
+Decode a VerifableURI value content.
+
+#### Parameters
+
+| Name   | Type     | Description                      |
+| :----- | :------- | :------------------------------- |
+| `data` | `string` | A value encoded as VerifiableURI |
+
+#### Returns
+
+`string` \| `number` \| `boolean` \| `URLDataWithHash`
+
+**`See`**
+
+https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md
+
+**`Example`**
+
+```ts
+decodeVerifiableURI("0x00006f357c6a0020eaba44f326e1405eed836279c9bdb0d62b6f8f7a6187f4fb8454607afd550ee368747470733a2f2f676f6f676c652e636f6d2f") =>
+{
+    verification: {
+        method: 'keccak256(utf8)',
+        data: '0xeaba44f326e1405eed836279c9bdb0d62b6f8f7a6187f4fb8454607afd550ee3',
+    },
+    url: 'https://google.com/',
+}
+```
+
+#### Defined in
+
+[LSP2ERC725YJSONSchema/decodeVerifiableURI/decodeVerifiableURI.ts:22](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP2ERC725YJSONSchema/decodeVerifiableURI/decodeVerifiableURI.ts#L22)
 
 ---
 
@@ -166,7 +205,7 @@ encodeAssetUrl(
 
 #### Defined in
 
-LSP2ERC725YJSONSchema/encodeAssetUrl/encodeAssetUrl.ts:25
+[LSP2ERC725YJSONSchema/encodeAssetUrl/encodeAssetUrl.ts:25](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP2ERC725YJSONSchema/encodeAssetUrl/encodeAssetUrl.ts#L25)
 
 ---
 
@@ -210,7 +249,48 @@ encodeJsonUrl(
 
 #### Defined in
 
-LSP2ERC725YJSONSchema/encodeJsonUrl/encodeJsonUrl.ts:25
+[LSP2ERC725YJSONSchema/encodeJsonUrl/encodeJsonUrl.ts:25](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP2ERC725YJSONSchema/encodeJsonUrl/encodeJsonUrl.ts#L25)
+
+---
+
+### encodeVerifiableURI
+
+▸ **encodeVerifiableURI**(`json`, `url`): `string` \| `false`
+
+Encode a VerifiableURI value content.
+
+#### Parameters
+
+| Name   | Type     | Description                            |
+| :----- | :------- | :------------------------------------- |
+| `json` | `object` | The JSON file content hosted at `url`. |
+| `url`  | `string` | The URL where the JSON file is hosted. |
+
+#### Returns
+
+`string` \| `false`
+
+The encoded value as `VerifiableURI`.
+
+**`See`**
+
+https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md
+
+**`Example`**
+
+```ts
+encodeVerifiableURI(
+  {
+       "name": "Tom",
+       "description": "Some random description about Tom"
+  },
+  "https://google.com/"
+) => "0x6f357c6a4dade694d7dd4081f46073e99ce898a9b53cf6988452904de7db5cc704a4184968747470733a2f2f676f6f676c652e636f6d2f"
+```
+
+#### Defined in
+
+[LSP2ERC725YJSONSchema/encodeVerifiableURI/encodeVerifiableURI.ts:26](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP2ERC725YJSONSchema/encodeVerifiableURI/encodeVerifiableURI.ts#L26)
 
 ---
 
@@ -253,7 +333,7 @@ generateSingletonKey(arrayDataKey, index) => `<bytes16(arrayDataKey)>:<bytes16(i
 
 #### Defined in
 
-LSP2ERC725YJSONSchema/generateArrayElementKeyAtIndex/generateArrayElementKeyAtIndex.ts:24
+[LSP2ERC725YJSONSchema/generateArrayElementKeyAtIndex/generateArrayElementKeyAtIndex.ts:24](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP2ERC725YJSONSchema/generateArrayElementKeyAtIndex/generateArrayElementKeyAtIndex.ts#L24)
 
 ---
 
@@ -299,7 +379,7 @@ generateArrayKey("RandomArrayDataKey[]") => keccak256("RandomArrayDataKey[]") = 
 
 #### Defined in
 
-LSP2ERC725YJSONSchema/generateArrayKey/generateArrayKey.ts:22
+[LSP2ERC725YJSONSchema/generateArrayKey/generateArrayKey.ts:22](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP2ERC725YJSONSchema/generateArrayKey/generateArrayKey.ts#L22)
 
 ---
 
@@ -357,7 +437,7 @@ generateMappingKey(bytes10Value, bytes20value) =>`<bytes10Value>:<0000>:<bytes20
 
 #### Defined in
 
-LSP2ERC725YJSONSchema/generateMappingKey/generateMappingKey.ts:37
+[LSP2ERC725YJSONSchema/generateMappingKey/generateMappingKey.ts:37](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP2ERC725YJSONSchema/generateMappingKey/generateMappingKey.ts#L37)
 
 ---
 
@@ -430,7 +510,7 @@ generateMappingWithGroupingKey(bytes6Value, bytes4Value, bytes20Value) => `<byte
 
 #### Defined in
 
-LSP2ERC725YJSONSchema/generateMappingWithGroupingKey/generateMappingWithGroupingKey.ts:51
+[LSP2ERC725YJSONSchema/generateMappingWithGroupingKey/generateMappingWithGroupingKey.ts:51](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP2ERC725YJSONSchema/generateMappingWithGroupingKey/generateMappingWithGroupingKey.ts#L51)
 
 ---
 
@@ -468,7 +548,7 @@ generateSingletonKey("RandomDataKey") => keccak256("RandomKeyName") = "0xb0c92ac
 
 #### Defined in
 
-LSP2ERC725YJSONSchema/generateSingletonKey/generateSingletonKey.ts:19
+[LSP2ERC725YJSONSchema/generateSingletonKey/generateSingletonKey.ts:19](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP2ERC725YJSONSchema/generateSingletonKey/generateSingletonKey.ts#L19)
 
 ---
 
@@ -508,7 +588,7 @@ isCompactBytesArray("0x0002") => false
 
 #### Defined in
 
-LSP2ERC725YJSONSchema/isCompactBytesArray/isCompactBytesArray.ts:21
+[LSP2ERC725YJSONSchema/isCompactBytesArray/isCompactBytesArray.ts:21](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP2ERC725YJSONSchema/isCompactBytesArray/isCompactBytesArray.ts#L21)
 
 ---
 
@@ -549,7 +629,7 @@ isValidArrayLengthValue("0x0000000000000000000000000000000000f60a") => false
 
 #### Defined in
 
-LSP2ERC725YJSONSchema/isValidArrayLengthValue/isValidArrayLengthValue.ts:22
+[LSP2ERC725YJSONSchema/isValidArrayLengthValue/isValidArrayLengthValue.ts:22](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP2ERC725YJSONSchema/isValidArrayLengthValue/isValidArrayLengthValue.ts#L22)
 
 ---
 
@@ -592,7 +672,7 @@ removeLastElementFromArrayAndMap(...) => { dataKeys: BytesLike[], dataValues: By
 
 #### Defined in
 
-LSP2ERC725YJSONSchema/removeElementFromArrayAndMap/removeElementFromArrayAndMap.ts:32
+[LSP2ERC725YJSONSchema/removeElementFromArrayAndMap/removeElementFromArrayAndMap.ts:32](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP2ERC725YJSONSchema/removeElementFromArrayAndMap/removeElementFromArrayAndMap.ts#L32)
 
 ---
 
@@ -638,4 +718,4 @@ removeLastElementFromArrayAndMap(...) => { dataKeys: BytesLike[], dataValues: By
 
 #### Defined in
 
-LSP2ERC725YJSONSchema/removeLastElementFromArrayAndMap/removeLastElementFromArrayAndMap.ts:22
+[LSP2ERC725YJSONSchema/removeLastElementFromArrayAndMap/removeLastElementFromArrayAndMap.ts:22](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP2ERC725YJSONSchema/removeLastElementFromArrayAndMap/removeLastElementFromArrayAndMap.ts#L22)

--- a/docs/modules/LSP3ProfileMetadata.md
+++ b/docs/modules/LSP3ProfileMetadata.md
@@ -51,7 +51,7 @@ getProfileMetadata(ERC725Y) =>
 
 #### Defined in
 
-LSP3ProfileMetadata/getProfileMetadata/getProfileMetadata.ts:53
+[LSP3ProfileMetadata/getProfileMetadata/getProfileMetadata.ts:53](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP3ProfileMetadata/getProfileMetadata/getProfileMetadata.ts#L53)
 
 ---
 
@@ -59,7 +59,7 @@ LSP3ProfileMetadata/getProfileMetadata/getProfileMetadata.ts:53
 
 ▸ **isProfileMetadata**(`object`): object is LSP3ProfileMetadataJSON
 
-Returns `true` is the passed object is an LSP3 Profile Metadata, `false` otherwise.
+Returns `true` if the passed object is an LSP3 Profile Metadata, `false` otherwise.
 
 #### Parameters
 
@@ -88,4 +88,49 @@ isProfileMetadata({ description: "", links: [], name: "", tags: [] }) => false
 
 #### Defined in
 
-LSP3ProfileMetadata/isProfileMetadata/isProfileMetadata.ts:16
+[LSP3ProfileMetadata/isProfileMetadata/isProfileMetadata.ts:16](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP3ProfileMetadata/isProfileMetadata/isProfileMetadata.ts#L16)
+
+---
+
+### setProfileMetadata
+
+▸ **setProfileMetadata**(`erc725y`, `json`, `url`, `signer?`): `Promise`\<`void`\>
+
+Set Profile metadata.
+
+#### Parameters
+
+| Name      | Type                      | Description                                                                  |
+| :-------- | :------------------------ | :--------------------------------------------------------------------------- |
+| `erc725y` | `BytesLike` \| `ERC725Y`  | The address of the Profile to set the metadata for.                          |
+| `json`    | `LSP3ProfileMetadataJSON` | The JSON file content hosted at `url`.                                       |
+| `url`     | `string`                  | The URL where the JSON file is hosted.                                       |
+| `signer?` | `Signer` \| `Wallet`      | The ethers `Signer`, address that is allowed to modify the Profile metadata. |
+
+#### Returns
+
+`Promise`\<`void`\>
+
+**`See`**
+
+https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-3-Profile-Metadata.md
+
+**`Example`**
+
+```ts
+setProfileMetadata(
+  "0x..."
+  {
+    LSP3Profile: {
+      "name": "Tom",
+      "description": "Some random description about Tom"
+    }
+  },
+  "https://google.com/",
+  signer
+)
+```
+
+#### Defined in
+
+[LSP3ProfileMetadata/setProfileMetadata/setProfileMetadata.ts:38](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP3ProfileMetadata/setProfileMetadata/setProfileMetadata.ts#L38)

--- a/docs/modules/LSP4DigitalAssetMetadata.md
+++ b/docs/modules/LSP4DigitalAssetMetadata.md
@@ -1,42 +1,5 @@
 # Module: LSP4DigitalAssetMetadata
 
-## LSP3
-
-### isAssetMetadata
-
-▸ **isAssetMetadata**(`object`): object is LSP4DigitalAssetMetadataJSON
-
-Returns `true` is the passed object is an LSP3 Profile Metadata, `false` otherwise.
-
-#### Parameters
-
-| Name     | Type  | Description                       |
-| :------- | :---- | :-------------------------------- |
-| `object` | `any` | The object that is to be checked. |
-
-#### Returns
-
-object is LSP4DigitalAssetMetadataJSON
-
-**`Since`**
-
-v0.0.1
-
-**`See`**
-
-https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-3-Profile-Metadata.md
-
-**`Example`**
-
-```ts
-isAssetMetadata({ LSP4Metadata: { description: "", links: [], images: [], assets: [] icon: [] } }) => true
-isAssetMetadata({ description: "", links: [], name: "", tags: [] }) => false
-```
-
-#### Defined in
-
-LSP4DigitalAssetMetadata/isAssetMetadata/isAssetMetadata.ts:16
-
 ## LSP4
 
 ### addDigitalAssetCreators
@@ -73,7 +36,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata
 
 #### Defined in
 
-LSP4DigitalAssetMetadata/addDigitalAssetCreators/addDigitalAssetCreators.ts:30
+[LSP4DigitalAssetMetadata/addDigitalAssetCreators/addDigitalAssetCreators.ts:30](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP4DigitalAssetMetadata/addDigitalAssetCreators/addDigitalAssetCreators.ts#L30)
 
 ---
 
@@ -110,7 +73,7 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata
 
 #### Defined in
 
-LSP4DigitalAssetMetadata/authenticateDigitalAssetCreators/authenticateDigitalAssetCreators.ts:27
+[LSP4DigitalAssetMetadata/authenticateDigitalAssetCreators/authenticateDigitalAssetCreators.ts:27](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP4DigitalAssetMetadata/authenticateDigitalAssetCreators/authenticateDigitalAssetCreators.ts#L27)
 
 ---
 
@@ -162,7 +125,7 @@ getAssetMetadata(ERC725Y) =>
 
 #### Defined in
 
-LSP4DigitalAssetMetadata/getAssetMetadata/getAssetMetadata.ts:45
+[LSP4DigitalAssetMetadata/getAssetMetadata/getAssetMetadata.ts:45](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP4DigitalAssetMetadata/getAssetMetadata/getAssetMetadata.ts#L45)
 
 ---
 
@@ -201,7 +164,46 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata
 
 #### Defined in
 
-LSP4DigitalAssetMetadata/getDigitalAssetCreators/getDigitalAssetCreators.ts:33
+[LSP4DigitalAssetMetadata/getDigitalAssetCreators/getDigitalAssetCreators.ts:33](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP4DigitalAssetMetadata/getDigitalAssetCreators/getDigitalAssetCreators.ts#L33)
+
+---
+
+### isAssetMetadata
+
+▸ **isAssetMetadata**(`object`): object is LSP4DigitalAssetMetadataJSON
+
+Returns `true` if the passed object is an LSP4 Asset Metadata, `false` otherwise.
+
+#### Parameters
+
+| Name     | Type  | Description                       |
+| :------- | :---- | :-------------------------------- |
+| `object` | `any` | The object that is to be checked. |
+
+#### Returns
+
+object is LSP4DigitalAssetMetadataJSON
+
+A boolean. `true` if object is `LSP4DigitalAssetMetadataJSON`, `false` otherwise.
+
+**`Since`**
+
+v0.0.1
+
+**`See`**
+
+https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-3-Profile-Metadata.md
+
+**`Example`**
+
+```ts
+isAssetMetadata({ LSP4Metadata: { description: "", links: [], images: [], assets: [] icon: [] } }) => true
+isAssetMetadata({ description: "", links: [], name: "", tags: [] }) => false
+```
+
+#### Defined in
+
+[LSP4DigitalAssetMetadata/isAssetMetadata/isAssetMetadata.ts:19](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP4DigitalAssetMetadata/isAssetMetadata/isAssetMetadata.ts#L19)
 
 ---
 
@@ -239,4 +241,4 @@ https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-4-DigitalAsset-Metadata
 
 #### Defined in
 
-LSP4DigitalAssetMetadata/removeDigitalAssetCreators/removeDigitalAssetCreators.ts:27
+[LSP4DigitalAssetMetadata/removeDigitalAssetCreators/removeDigitalAssetCreators.ts:27](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP4DigitalAssetMetadata/removeDigitalAssetCreators/removeDigitalAssetCreators.ts#L27)

--- a/docs/modules/LSP5ReceivedAssets.md
+++ b/docs/modules/LSP5ReceivedAssets.md
@@ -38,7 +38,7 @@ generateReceivedAssetKeys(...) => { lsp5DataKeys: BytesLike[], lsp5DataValues: B
 
 #### Defined in
 
-LSP5ReceivedAssets/generateReceivedAssetKeys/generateReceivedAssetKeys.ts:32
+[LSP5ReceivedAssets/generateReceivedAssetKeys/generateReceivedAssetKeys.ts:32](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP5ReceivedAssets/generateReceivedAssetKeys/generateReceivedAssetKeys.ts#L32)
 
 ---
 
@@ -77,4 +77,4 @@ generateSentAssetKeys(...) => { lsp5DataKeys: BytesLike[], lsp5DataValues: Bytes
 
 #### Defined in
 
-LSP5ReceivedAssets/generateSentAssetKeys/generateSentAssetKeys.ts:34
+[LSP5ReceivedAssets/generateSentAssetKeys/generateSentAssetKeys.ts:34](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP5ReceivedAssets/generateSentAssetKeys/generateSentAssetKeys.ts#L34)

--- a/docs/modules/LSP6KeyManager.md
+++ b/docs/modules/LSP6KeyManager.md
@@ -41,7 +41,7 @@ createValidityTimestamp(5, 10) => `0x0000000000000000000000000000000500000000000
 
 #### Defined in
 
-LSP6KeyManager/createValidityTimestamp/createValidityTimestamp.ts:21
+[LSP6KeyManager/createValidityTimestamp/createValidityTimestamp.ts:21](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP6KeyManager/createValidityTimestamp/createValidityTimestamp.ts#L21)
 
 ---
 
@@ -106,7 +106,7 @@ decodeAllowedCalls("0x002000000002cafecafecafecafecafecafecafecafecafecafe24871b
 
 #### Defined in
 
-LSP6KeyManager/decodeAllowedCalls/decodeAllowedCalls.ts:37
+[LSP6KeyManager/decodeAllowedCalls/decodeAllowedCalls.ts:37](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP6KeyManager/decodeAllowedCalls/decodeAllowedCalls.ts#L37)
 
 ---
 
@@ -154,7 +154,7 @@ decodeAllowedERC725YDataKeys("0x0002cafe000abeefdeadbeef0000cafe") =>
 
 #### Defined in
 
-LSP6KeyManager/decodeAllowedERC725YDataKeys/decodeAllowedERC725YDataKeys.ts:27
+[LSP6KeyManager/decodeAllowedERC725YDataKeys/decodeAllowedERC725YDataKeys.ts:27](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP6KeyManager/decodeAllowedERC725YDataKeys/decodeAllowedERC725YDataKeys.ts#L27)
 
 ---
 
@@ -219,7 +219,7 @@ decodePermissions([
 
 #### Defined in
 
-LSP6KeyManager/decodePermissions/decodePermissions.ts:53
+[LSP6KeyManager/decodePermissions/decodePermissions.ts:53](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP6KeyManager/decodePermissions/decodePermissions.ts#L53)
 
 ---
 
@@ -279,7 +279,7 @@ encodeAllowedCalls(
 
 #### Defined in
 
-LSP6KeyManager/encodeAllowedCalls/encodeAllowedCalls.ts:39
+[LSP6KeyManager/encodeAllowedCalls/encodeAllowedCalls.ts:39](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP6KeyManager/encodeAllowedCalls/encodeAllowedCalls.ts#L39)
 
 ---
 
@@ -325,7 +325,7 @@ encodeAllowedERC725YDataKeys([
 
 #### Defined in
 
-LSP6KeyManager/encodeAllowedERC725YDataKeys/encodeAllowedERC725YDataKeys.ts:25
+[LSP6KeyManager/encodeAllowedERC725YDataKeys/encodeAllowedERC725YDataKeys.ts:25](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP6KeyManager/encodeAllowedERC725YDataKeys/encodeAllowedERC725YDataKeys.ts#L25)
 
 ---
 
@@ -381,4 +381,4 @@ encodePermissions([
 
 #### Defined in
 
-LSP6KeyManager/encodePermissions/encodePermissions.ts:37
+[LSP6KeyManager/encodePermissions/encodePermissions.ts:37](https://github.com/lukso-network/lsp-utils/blob/b49578e/src/LSP6KeyManager/encodePermissions/encodePermissions.ts#L37)

--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
         "prepare": "husky install"
     },
     "dependencies": {
-        "@erc725/erc725.js": "0.23.0",
+        "@erc725/erc725.js": "0.25.0",
         "@erc725/smart-contracts": "^7.0.0",
-        "@lukso/lsp-smart-contracts": "0.14.0",
+        "@lukso/lsp-smart-contracts": "0.15.0",
         "@openzeppelin/contracts": "4.9.2",
         "assert": "2.1.0",
         "ethers": "^6.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     dependencies:
       '@erc725/erc725.js':
-        specifier: 0.23.0
-        version: 0.23.0
+        specifier: 0.25.0
+        version: 0.25.0
       '@erc725/smart-contracts':
         specifier: ^7.0.0
         version: 7.0.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@lukso/lsp-smart-contracts':
-        specifier: 0.14.0
-        version: 0.14.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+        specifier: 0.15.0
+        version: 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@openzeppelin/contracts':
         specifier: 4.9.2
         version: 4.9.2
@@ -93,309 +93,6 @@ importers:
       vite-plugin-dts:
         specifier: ^3.6.0
         version: 3.7.2(@types/node@20.5.1)(rollup@3.29.4)(typescript@5.3.3)(vite@4.5.2(@types/node@20.5.1))
-
-  packages/IPFS:
-    dependencies:
-      '@lukso/lsp-utils-constants':
-        specifier: workspace:*
-        version: link:../constants
-    devDependencies:
-      '@lukso/tsconfig':
-        specifier: workspace:*
-        version: link:../tsconfig
-      eslint:
-        specifier: ^7.32.0
-        version: 7.32.0
-      unbuild:
-        specifier: ^2.0.0
-        version: 2.0.0(typescript@5.3.3)
-
-  packages/LSP12IssuedAssets:
-    dependencies:
-      '@erc725/smart-contracts':
-        specifier: ^7.0.0
-        version: 7.0.0(@babel/core@7.23.9)
-      '@lukso/lsp-smart-contracts':
-        specifier: 0.14.0
-        version: 0.14.0(@babel/core@7.23.9)
-      '@lukso/lsp-utils-constants':
-        specifier: workspace:*
-        version: link:../constants
-      '@lukso/lsp-utils-helpers':
-        specifier: workspace:*
-        version: link:../helpers
-      '@lukso/lsp2-utils':
-        specifier: workspace:*
-        version: link:../LSP2ERC725YJSONSchema
-      '@lukso/lsp4-utils':
-        specifier: workspace:*
-        version: link:../LSP4DigitalAssetMetadata
-      ethers:
-        specifier: ^6.8.0
-        version: 6.10.0
-    devDependencies:
-      '@lukso/tsconfig':
-        specifier: workspace:*
-        version: link:../tsconfig
-      '@typechain/ethers-v6':
-        specifier: ^0.4.0
-        version: 0.4.3(ethers@6.10.0)(typechain@8.3.2)(typescript@5.3.3)
-      eslint:
-        specifier: ^7.32.0
-        version: 7.32.0
-      typechain:
-        specifier: ^8.3.2
-        version: 8.3.2(typescript@5.3.3)
-      unbuild:
-        specifier: ^2.0.0
-        version: 2.0.0(typescript@5.3.3)
-
-  packages/LSP23LinkedContractsFactory:
-    dependencies:
-      '@lukso/lsp-smart-contracts':
-        specifier: 0.14.0
-        version: 0.14.0(@babel/core@7.23.9)
-      '@lukso/lsp-utils-constants':
-        specifier: workspace:*
-        version: link:../constants
-      '@lukso/lsp-utils-helpers':
-        specifier: workspace:*
-        version: link:../helpers
-      '@lukso/lsp2-utils':
-        specifier: workspace:*
-        version: link:../LSP2ERC725YJSONSchema
-      ethers:
-        specifier: ^6.8.0
-        version: 6.10.0
-    devDependencies:
-      '@lukso/tsconfig':
-        specifier: workspace:*
-        version: link:../tsconfig
-      '@typechain/ethers-v6':
-        specifier: ^0.4.0
-        version: 0.4.3(ethers@6.10.0)(typechain@8.3.2)(typescript@5.3.3)
-      eslint:
-        specifier: ^7.32.0
-        version: 7.32.0
-      typechain:
-        specifier: ^8.3.2
-        version: 8.3.2(typescript@5.3.3)
-      unbuild:
-        specifier: ^2.0.0
-        version: 2.0.0(typescript@5.3.3)
-
-  packages/LSP2ERC725YJSONSchema:
-    dependencies:
-      '@erc725/smart-contracts':
-        specifier: ^7.0.0
-        version: 7.0.0(@babel/core@7.23.9)
-      '@lukso/lsp-smart-contracts':
-        specifier: 0.14.0
-        version: 0.14.0(@babel/core@7.23.9)
-      ethers:
-        specifier: ^6.8.0
-        version: 6.10.0
-    devDependencies:
-      '@lukso/tsconfig':
-        specifier: workspace:*
-        version: link:../tsconfig
-      '@typechain/ethers-v6':
-        specifier: ^0.4.0
-        version: 0.4.3(ethers@6.10.0)(typechain@8.3.2)(typescript@5.3.3)
-      eslint:
-        specifier: ^7.32.0
-        version: 7.32.0
-      typechain:
-        specifier: ^8.3.2
-        version: 8.3.2(typescript@5.3.3)
-      unbuild:
-        specifier: ^2.0.0
-        version: 2.0.0(typescript@5.3.3)
-
-  packages/LSP3ProfileMetadata:
-    dependencies:
-      '@erc725/smart-contracts':
-        specifier: ^7.0.0
-        version: 7.0.0(@babel/core@7.23.9)
-      '@lukso/ipfs-utils':
-        specifier: workspace:*
-        version: link:../IPFS
-      '@lukso/lsp-smart-contracts':
-        specifier: 0.14.0
-        version: 0.14.0(@babel/core@7.23.9)
-      '@lukso/lsp-utils-constants':
-        specifier: workspace:*
-        version: link:../constants
-      '@lukso/lsp-utils-helpers':
-        specifier: workspace:*
-        version: link:../helpers
-      ethers:
-        specifier: ^6.8.0
-        version: 6.10.0
-    devDependencies:
-      '@lukso/tsconfig':
-        specifier: workspace:*
-        version: link:../tsconfig
-      '@typechain/ethers-v6':
-        specifier: ^0.4.0
-        version: 0.4.3(ethers@6.10.0)(typechain@8.3.2)(typescript@5.3.3)
-      eslint:
-        specifier: ^7.32.0
-        version: 7.32.0
-      typechain:
-        specifier: ^8.3.2
-        version: 8.3.2(typescript@5.3.3)
-      unbuild:
-        specifier: ^2.0.0
-        version: 2.0.0(typescript@5.3.3)
-
-  packages/LSP4DigitalAssetMetadata:
-    dependencies:
-      '@erc725/smart-contracts':
-        specifier: ^7.0.0
-        version: 7.0.0(@babel/core@7.23.9)
-      '@lukso/ipfs-utils':
-        specifier: workspace:*
-        version: link:../IPFS
-      '@lukso/lsp-smart-contracts':
-        specifier: 0.14.0
-        version: 0.14.0(@babel/core@7.23.9)
-      '@lukso/lsp-utils-constants':
-        specifier: workspace:*
-        version: link:../constants
-      '@lukso/lsp-utils-helpers':
-        specifier: workspace:*
-        version: link:../helpers
-      '@lukso/lsp2-utils':
-        specifier: workspace:*
-        version: link:../LSP2ERC725YJSONSchema
-      ethers:
-        specifier: ^6.8.0
-        version: 6.10.0
-    devDependencies:
-      '@lukso/tsconfig':
-        specifier: workspace:*
-        version: link:../tsconfig
-      '@typechain/ethers-v6':
-        specifier: ^0.4.0
-        version: 0.4.3(ethers@6.10.0)(typechain@8.3.2)(typescript@5.3.3)
-      eslint:
-        specifier: ^7.32.0
-        version: 7.32.0
-      typechain:
-        specifier: ^8.3.2
-        version: 8.3.2(typescript@5.3.3)
-      unbuild:
-        specifier: ^2.0.0
-        version: 2.0.0(typescript@5.3.3)
-
-  packages/LSP5ReceivedAssets:
-    dependencies:
-      '@erc725/smart-contracts':
-        specifier: ^7.0.0
-        version: 7.0.0(@babel/core@7.23.9)
-      '@lukso/lsp-smart-contracts':
-        specifier: 0.14.0
-        version: 0.14.0(@babel/core@7.23.9)
-      '@lukso/lsp2-utils':
-        specifier: workspace:*
-        version: link:../LSP2ERC725YJSONSchema
-      ethers:
-        specifier: ^6.8.0
-        version: 6.10.0
-    devDependencies:
-      '@lukso/tsconfig':
-        specifier: workspace:*
-        version: link:../tsconfig
-      '@typechain/ethers-v6':
-        specifier: ^0.4.0
-        version: 0.4.3(ethers@6.10.0)(typechain@8.3.2)(typescript@5.3.3)
-      eslint:
-        specifier: ^7.32.0
-        version: 7.32.0
-      typechain:
-        specifier: ^8.3.2
-        version: 8.3.2(typescript@5.3.3)
-      unbuild:
-        specifier: ^2.0.0
-        version: 2.0.0(typescript@5.3.3)
-
-  packages/LSP6KeyManager:
-    dependencies:
-      '@lukso/lsp-smart-contracts':
-        specifier: 0.14.0
-        version: 0.14.0(@babel/core@7.23.9)
-      '@lukso/lsp-utils-constants':
-        specifier: workspace:*
-        version: link:../constants
-      ethers:
-        specifier: ^6.8.0
-        version: 6.10.0
-    devDependencies:
-      '@lukso/tsconfig':
-        specifier: workspace:*
-        version: link:../tsconfig
-      eslint:
-        specifier: ^7.32.0
-        version: 7.32.0
-      unbuild:
-        specifier: ^2.0.0
-        version: 2.0.0(typescript@5.3.3)
-
-  packages/constants:
-    dependencies:
-      '@lukso/lsp-smart-contracts':
-        specifier: 0.14.0
-        version: 0.14.0(@babel/core@7.23.9)
-      ethers:
-        specifier: ^6.8.0
-        version: 6.10.0
-    devDependencies:
-      '@lukso/tsconfig':
-        specifier: workspace:*
-        version: link:../tsconfig
-      eslint:
-        specifier: ^7.32.0
-        version: 7.32.0
-      unbuild:
-        specifier: ^2.0.0
-        version: 2.0.0(typescript@5.3.3)
-
-  packages/helpers:
-    dependencies:
-      '@erc725/smart-contracts':
-        specifier: ^7.0.0
-        version: 7.0.0(@babel/core@7.23.9)
-      '@lukso/lsp-smart-contracts':
-        specifier: 0.14.0
-        version: 0.14.0(@babel/core@7.23.9)
-      '@lukso/lsp-utils-constants':
-        specifier: workspace:*
-        version: link:../constants
-      '@openzeppelin/contracts':
-        specifier: 4.9.2
-        version: 4.9.2
-      ethers:
-        specifier: ^6.8.0
-        version: 6.10.0
-    devDependencies:
-      '@lukso/tsconfig':
-        specifier: workspace:*
-        version: link:../tsconfig
-      '@typechain/ethers-v6':
-        specifier: ^0.4.0
-        version: 0.4.3(ethers@6.10.0)(typechain@8.3.2)(typescript@5.3.3)
-      eslint:
-        specifier: ^7.32.0
-        version: 7.32.0
-      typechain:
-        specifier: ^8.3.2
-        version: 8.3.2(typescript@5.3.3)
-      unbuild:
-        specifier: ^2.0.0
-        version: 2.0.0(typescript@5.3.3)
-
-  packages/tsconfig: {}
 
 packages:
 
@@ -614,8 +311,11 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@erc725/erc725.js@0.23.0':
-    resolution: {integrity: sha512-v2qPnH7IXSh4td3br+LNXdhfiFrtx/AOBnNbFZKZVHQdVdapKAtZVmrKV1svTlztxxRgQQ24wLgEMkxr9GiguA==}
+  '@erc725/erc725.js@0.25.0':
+    resolution: {integrity: sha512-kE4/6XAm52AtdErHDeD9N0NFDD/3nG0xuOIomN8EvItPPvbcFAsvZY4B+SDWkccOGTdLOQEr/ef4FOgNUfSRPQ==}
+
+  '@erc725/smart-contracts@6.0.0':
+    resolution: {integrity: sha512-6okutGGL9xbg/MSgAof2FU1UcSNE/z3p9TORlROVGaM3gi1A6FQQ7fDqtBYkPtvHureX8yS9gP7xPt3PRbP43Q==}
 
   '@erc725/smart-contracts@7.0.0':
     resolution: {integrity: sha512-O/Ki+0JqRStPUHXjdU4JhDUzncLdC33c0xjTRiwWwBYbxL77LlWaPfG96fWp2hF2kdR0zNYvcsnZZds+uj2QMg==}
@@ -1047,8 +747,71 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@lukso/lsp-smart-contracts@0.14.0':
-    resolution: {integrity: sha512-HjMpO/DfcAnL2YAoGSq4TazwsKof3CClyi33cwkOIdH7b81DMP5Z4LLjOjAGURrJlMj8wH4cLp5+4nvZ4NVSIA==}
+  '@lukso/lsp-smart-contracts@0.15.0':
+    resolution: {integrity: sha512-5zMELJsGPxyMo3ikKqBOLIGxqTxxZeCfg5bgiqHmNqONcNTmQpfrQEY+n6icC/+Pl7Pcx1Rz22ld3hpw7oYj6Q==}
+
+  '@lukso/lsp0-contracts@0.15.0':
+    resolution: {integrity: sha512-dKQu9juDJNxKdJMHkF3wOfjC/VZZW+RonQ5hSw9kBhLAhyFd6SVYU3VSUOYG3G3bLDAE9We+DeONc0N/j4zjIQ==}
+
+  '@lukso/lsp1-contracts@0.15.0':
+    resolution: {integrity: sha512-8xhehHa+EOiJ9MfqDStFgF8ot4scER7ip+MCKGF7Ybrv8aWlXyJgfl7H5TX8DA9XZbqb096GKicNi7v79H2hQg==}
+
+  '@lukso/lsp10-contracts@0.15.0':
+    resolution: {integrity: sha512-LXyOOCD43sHtQxyp98utUwxaU+r2MA8TvqXBibxjHxD20/L7vYGSxHqDX493/zUtfCUIMUELuj6a1+NGscbBTw==}
+
+  '@lukso/lsp12-contracts@0.15.0':
+    resolution: {integrity: sha512-fSq8syWvRkHb0hOtVubJ3YyqLoZ0IDGT+FC3W79nKCP5OYpZt1VwWwUsqQlBUImrrtTaP9Vdin9aNGD9umtCqA==}
+
+  '@lukso/lsp14-contracts@0.15.0':
+    resolution: {integrity: sha512-dqTY9QjGk9b+lZFchqm1ZAJ5c/AJlTPwZtXsqRyJrSS5WHwx3jteh/0mCt/1fmv8dzqgMadtOIJVpEXPannMWw==}
+
+  '@lukso/lsp16-contracts@0.15.0':
+    resolution: {integrity: sha512-zt58Uq4nWoGRMlSvZYYKM+YWmqXaWqDymiB9+v42kgNFvdpaK2bnt6zhoZOCd+D5YyQ5X7koooxR05amyxLe2w==}
+
+  '@lukso/lsp17-contracts@0.15.0':
+    resolution: {integrity: sha512-lEMayqU5SR2ysgs08cqzsW50DrJrTtsjoIyqvctaIMZF9DSEHRTn1yh8ePzNNcNr3tQcDmaxwtPAuYD469tXHQ==}
+
+  '@lukso/lsp17contractextension-contracts@0.15.0':
+    resolution: {integrity: sha512-fwLrXi1jyiw6DlP6mt+NTweSxyPI3KaKk5UN9OwuT5KbaC7Upm50TFuA/IX+V4gY8/iVdr6uhy7nLg1+LQpSAw==}
+
+  '@lukso/lsp1delegate-contracts@0.15.0':
+    resolution: {integrity: sha512-FuBzBsJZdbtHBF1q6IsCpd94xD/Ce7kHrZASWjSWIU6lzqEWpJcItZ95EkRPmJjAqYlkwzz3ry0wfY8nAIbJrA==}
+
+  '@lukso/lsp2-contracts@0.15.0':
+    resolution: {integrity: sha512-3SnuAmdZo+Y7pv5E3DajguCfawf/2KEygAjpV3QNfuK5MnBtNSYTg9nmjvP/+VcAG9nNlkMSGba43s5Jz0TuSw==}
+
+  '@lukso/lsp20-contracts@0.15.0':
+    resolution: {integrity: sha512-TfAM9tN6zzIQXq0xq3uE0zkBfVjQ52jXY69fvMSBqs/PsKV49J/T4tH9pMqazTgCF1PlAOnoA8m2MTdjJ7OCqA==}
+
+  '@lukso/lsp23-contracts@0.15.0':
+    resolution: {integrity: sha512-IQqvK19PyLEAb/6gscLqn1MVy9zKOflQCVNIQmjgMhv6d89FvItwfvLk81aycSUELX5XANbzK14dM0x/ydEQAg==}
+
+  '@lukso/lsp25-contracts@0.15.0':
+    resolution: {integrity: sha512-GYgnosvrWhNbkZ1lpZ9InPKF8dB1FGb3N0FvpV98ZIG28wKGdBkKnT54ot2bMwmW6oeRuz7/8hAGbcpCKVa/WA==}
+
+  '@lukso/lsp3-contracts@0.15.0':
+    resolution: {integrity: sha512-GgL9Ys9HvCuRCJ2/XB6abAwHBCE+LYMPY5vcHnZ67U7cgVgy9sc7z9VDTcBwZygsKUMuNrrnph4MC0G90rALjg==}
+
+  '@lukso/lsp4-contracts@0.15.0':
+    resolution: {integrity: sha512-M85S5DN3hqHTIfTs7Cs1dqM4EE2ftEZfh0RcPV00+Fgo2IID8QQxKNFiGP1I59Upn6GsDar/RJpFyV1SCnAOGw==}
+
+  '@lukso/lsp5-contracts@0.15.0':
+    resolution: {integrity: sha512-mrFp5RAY/rswka8D8rfh25T30yipiQsH87pw+f3t0BLnxbkRt9XiUD4vWD9v8D04TO8wQWuTuFJutObirgFwEg==}
+
+  '@lukso/lsp6-contracts@0.15.0':
+    resolution: {integrity: sha512-nJ1V5x6RP6WlOy2yX/SqNA1M07fPjmmsGQRIWJ1/K+oZKcKSPXKRkaRfzbGo9uzBYS4sDa0E2Q4UMItjaTokoQ==}
+
+  '@lukso/lsp7-contracts@0.15.0':
+    resolution: {integrity: sha512-9kQmwL49CA90vCF1dneG44DdtkNzmnWZ7JzLIopizLw8pnKxhvTAnnJFdsDUVZiDqH3l61RBY51IpEBj+u5yXA==}
+
+  '@lukso/lsp8-contracts@0.15.0':
+    resolution: {integrity: sha512-7iWN55lSivJ8PUchY5ocrHjeQ/SeaL2zVrLBW+224AkFQn3no1hhZ8q9mqAbwxv0CEIt5L2x+2RclZq3yMa2uw==}
+
+  '@lukso/lsp9-contracts@0.15.0':
+    resolution: {integrity: sha512-wyE4RR9toZrNTcJZXtHHeLfUEqQzE+Zn5nmailAspBTo/sUmW6AjUxl4PKHG/nLYrcjb3wvZ4mTCnbFkGsRHwg==}
+
+  '@lukso/universalprofile-contracts@0.15.0':
+    resolution: {integrity: sha512-umW4mpC2HtUNW+Cxi4rP+jgWDzpGQfAiDHYiqVB7TunIO6YzlVez8i4DhrmN/lInYQSuk6+kHpUo1jEO8kiJxQ==}
 
   '@metamask/eth-sig-util@4.0.1':
     resolution: {integrity: sha512-tghyZKLHZjcdlDqCA3gNZmLeR0XvOE9U1qoQO9ohyAZT6Pya+H9vkBPcsyXytmYLNgVoin7CKCmweo/R43V+tQ==}
@@ -5850,7 +5613,7 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@erc725/erc725.js@0.23.0':
+  '@erc725/erc725.js@0.25.0':
     dependencies:
       add: 2.0.6
       ethereumjs-util: 7.1.5
@@ -5860,11 +5623,11 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@erc725/smart-contracts@7.0.0(@babel/core@7.23.9)':
+  '@erc725/smart-contracts@6.0.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
       '@openzeppelin/contracts': 4.9.5
       '@openzeppelin/contracts-upgradeable': 4.9.5
-      solidity-bytes-utils: 0.8.0(@babel/core@7.23.9)
+      solidity-bytes-utils: 0.8.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@babel/core'
       - bufferutil
@@ -6357,13 +6120,29 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  '@lukso/lsp-smart-contracts@0.14.0(@babel/core@7.23.9)':
+  '@lukso/lsp-smart-contracts@0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
-      '@account-abstraction/contracts': 0.6.0
-      '@erc725/smart-contracts': 7.0.0(@babel/core@7.23.9)
-      '@openzeppelin/contracts': 4.9.2
-      '@openzeppelin/contracts-upgradeable': 4.9.5
-      solidity-bytes-utils: 0.8.0(@babel/core@7.23.9)
+      '@lukso/lsp0-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp1-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp10-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp12-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp14-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp16-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp17-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp17contractextension-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp1delegate-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp2-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp20-contracts': 0.15.0
+      '@lukso/lsp23-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp25-contracts': 0.15.0
+      '@lukso/lsp3-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp4-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp5-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp6-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp7-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp8-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp9-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/universalprofile-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@babel/core'
       - bufferutil
@@ -6371,13 +6150,248 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@lukso/lsp-smart-contracts@0.14.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+  '@lukso/lsp0-contracts@0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
-      '@account-abstraction/contracts': 0.6.0
+      '@erc725/smart-contracts': 7.0.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp1-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp14-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp17contractextension-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp2-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp20-contracts': 0.15.0
+      '@openzeppelin/contracts': 4.9.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@lukso/lsp1-contracts@0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@lukso/lsp2-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@openzeppelin/contracts': 4.9.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@lukso/lsp10-contracts@0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@erc725/smart-contracts': 6.0.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp2-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@lukso/lsp12-contracts@0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@lukso/lsp2-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@lukso/lsp14-contracts@0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@erc725/smart-contracts': 7.0.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp1-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@lukso/lsp16-contracts@0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+    dependencies:
       '@erc725/smart-contracts': 7.0.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@openzeppelin/contracts': 4.9.2
       '@openzeppelin/contracts-upgradeable': 4.9.5
-      solidity-bytes-utils: 0.8.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@lukso/lsp17-contracts@0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@account-abstraction/contracts': 0.6.0
+      '@erc725/smart-contracts': 7.0.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp14-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp17contractextension-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp20-contracts': 0.15.0
+      '@lukso/lsp6-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@openzeppelin/contracts': 4.9.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@lukso/lsp17contractextension-contracts@0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@erc725/smart-contracts': 7.0.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@openzeppelin/contracts': 4.9.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@lukso/lsp1delegate-contracts@0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@erc725/smart-contracts': 7.0.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp1-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp10-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp5-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp7-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp8-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp9-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@openzeppelin/contracts': 4.9.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@lukso/lsp2-contracts@0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@erc725/smart-contracts': 7.0.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@openzeppelin/contracts': 4.9.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@lukso/lsp20-contracts@0.15.0': {}
+
+  '@lukso/lsp23-contracts@0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@erc725/smart-contracts': 7.0.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/universalprofile-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@openzeppelin/contracts': 4.9.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@lukso/lsp25-contracts@0.15.0':
+    dependencies:
+      '@openzeppelin/contracts': 4.9.5
+
+  '@lukso/lsp3-contracts@0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@lukso/lsp2-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@lukso/lsp4-contracts@0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@erc725/smart-contracts': 7.0.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp2-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@lukso/lsp5-contracts@0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@erc725/smart-contracts': 7.0.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp2-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@lukso/lsp6-contracts@0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@erc725/smart-contracts': 7.0.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp1-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp14-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp17contractextension-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp2-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp20-contracts': 0.15.0
+      '@lukso/lsp25-contracts': 0.15.0
+      '@openzeppelin/contracts': 4.9.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@lukso/lsp7-contracts@0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@erc725/smart-contracts': 7.0.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp1-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp17contractextension-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp2-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp4-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@openzeppelin/contracts': 4.9.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@lukso/lsp8-contracts@0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@erc725/smart-contracts': 7.0.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp1-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp17contractextension-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp2-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp4-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@openzeppelin/contracts': 4.9.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@lukso/lsp9-contracts@0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@erc725/smart-contracts': 7.0.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp1-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp6-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@openzeppelin/contracts': 4.9.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@lukso/universalprofile-contracts@0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@erc725/smart-contracts': 7.0.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp0-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@lukso/lsp3-contracts': 0.15.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@openzeppelin/contracts': 4.9.5
     transitivePeerDependencies:
       - '@babel/core'
       - bufferutil
@@ -6871,27 +6885,6 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@truffle/hdwallet-provider@2.1.15(@babel/core@7.23.9)':
-    dependencies:
-      '@ethereumjs/common': 2.6.5
-      '@ethereumjs/tx': 3.5.2
-      '@metamask/eth-sig-util': 4.0.1
-      '@truffle/hdwallet': 0.1.4
-      '@types/ethereum-protocol': 1.0.5
-      '@types/web3': 1.0.20
-      '@types/web3-provider-engine': 14.0.4
-      ethereum-cryptography: 1.1.2
-      ethereum-protocol: 1.0.1
-      ethereumjs-util: 7.1.5
-      web3: 1.10.0
-      web3-provider-engine: 16.0.3(@babel/core@7.23.9)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-
   '@truffle/hdwallet-provider@2.1.15(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
       '@ethereumjs/common': 2.6.5
@@ -6932,14 +6925,6 @@ snapshots:
   '@typechain/ethers-v6@0.4.3(ethers@6.10.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.3.3))(typescript@5.3.3)':
     dependencies:
       ethers: 6.10.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      lodash: 4.17.21
-      ts-essentials: 7.0.3(typescript@5.3.3)
-      typechain: 8.3.2(typescript@5.3.3)
-      typescript: 5.3.3
-
-  '@typechain/ethers-v6@0.4.3(ethers@6.10.0)(typechain@8.3.2)(typescript@5.3.3)':
-    dependencies:
-      ethers: 6.10.0
       lodash: 4.17.21
       ts-essentials: 7.0.3(typescript@5.3.3)
       typechain: 8.3.2(typescript@5.3.3)
@@ -8424,19 +8409,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  eth-lib@0.1.29:
-    dependencies:
-      bn.js: 4.12.0
-      elliptic: 6.5.4
-      nano-json-stream-parser: 0.1.2
-      servify: 0.1.12
-      ws: 3.3.3
-      xhr-request-promise: 0.1.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   eth-lib@0.1.29(bufferutil@4.0.8)(utf-8-validate@5.0.10):
     dependencies:
       bn.js: 4.12.0
@@ -8641,19 +8613,6 @@ snapshots:
       '@ethersproject/wallet': 5.7.0
       '@ethersproject/web': 5.7.1
       '@ethersproject/wordlists': 5.7.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  ethers@6.10.0:
-    dependencies:
-      '@adraffy/ens-normalize': 1.10.0
-      '@noble/curves': 1.2.0
-      '@noble/hashes': 1.3.2
-      '@types/node': 18.15.13
-      aes-js: 4.0.0-beta.5
-      tslib: 2.4.0
-      ws: 8.5.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -10769,16 +10728,6 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  solidity-bytes-utils@0.8.0(@babel/core@7.23.9):
-    dependencies:
-      '@truffle/hdwallet-provider': 2.1.15(@babel/core@7.23.9)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-
   solidity-bytes-utils@0.8.0(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10):
     dependencies:
       '@truffle/hdwallet-provider': 2.1.15(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -10947,24 +10896,6 @@ snapshots:
       css-what: 6.1.0
       csso: 5.0.5
       picocolors: 1.0.0
-
-  swarm-js@0.1.42:
-    dependencies:
-      bluebird: 3.7.2
-      buffer: 5.7.1
-      eth-lib: 0.1.29
-      fs-extra: 4.0.3
-      got: 11.8.6
-      mime-types: 2.1.35
-      mkdirp-promise: 5.0.1
-      mock-fs: 4.14.0
-      setimmediate: 1.0.5
-      tar: 4.4.19
-      xhr-request: 1.1.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
 
   swarm-js@0.1.42(bufferutil@4.0.8)(utf-8-validate@5.0.10):
     dependencies:
@@ -11350,16 +11281,6 @@ snapshots:
       semver: 7.5.4
       typescript: 5.3.3
 
-  web3-bzz@1.10.0:
-    dependencies:
-      '@types/node': 12.20.55
-      got: 12.1.0
-      swarm-js: 0.1.42
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   web3-bzz@1.10.0(bufferutil@4.0.8)(utf-8-validate@5.0.10):
     dependencies:
       '@types/node': 12.20.55
@@ -11524,37 +11445,6 @@ snapshots:
       - encoding
       - supports-color
 
-  web3-provider-engine@16.0.3(@babel/core@7.23.9):
-    dependencies:
-      '@ethereumjs/tx': 3.5.2
-      async: 2.6.4
-      backoff: 2.5.0
-      clone: 2.1.2
-      cross-fetch: 2.2.6
-      eth-block-tracker: 4.4.3(@babel/core@7.23.9)
-      eth-json-rpc-filters: 4.2.2
-      eth-json-rpc-infura: 5.1.0
-      eth-json-rpc-middleware: 6.0.0
-      eth-rpc-errors: 3.0.0
-      eth-sig-util: 1.4.2
-      ethereumjs-block: 1.7.1
-      ethereumjs-util: 5.2.1
-      ethereumjs-vm: 2.6.0
-      json-stable-stringify: 1.1.1
-      promise-to-callback: 1.0.0
-      readable-stream: 2.3.8
-      request: 2.88.2
-      semaphore: 1.1.0
-      ws: 5.2.3
-      xhr: 2.6.0
-      xtend: 4.0.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-
   web3-provider-engine@16.0.3(@babel/core@7.23.9)(bufferutil@4.0.8)(utf-8-validate@5.0.10):
     dependencies:
       '@ethereumjs/tx': 3.5.2
@@ -11648,21 +11538,6 @@ snapshots:
       randombytes: 2.1.0
       utf8: 3.0.0
 
-  web3@1.10.0:
-    dependencies:
-      web3-bzz: 1.10.0
-      web3-core: 1.10.0
-      web3-eth: 1.10.0
-      web3-eth-personal: 1.10.0
-      web3-net: 1.10.0
-      web3-shh: 1.10.0
-      web3-utils: 1.10.0
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-
   web3@1.10.0(bufferutil@4.0.8)(utf-8-validate@5.0.10):
     dependencies:
       web3-bzz: 1.10.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -11735,12 +11610,6 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@3.3.3:
-    dependencies:
-      async-limiter: 1.0.1
-      safe-buffer: 5.1.2
-      ultron: 1.1.1
-
   ws@3.3.3(bufferutil@4.0.8)(utf-8-validate@5.0.10):
     dependencies:
       async-limiter: 1.0.1
@@ -11749,10 +11618,6 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.0.8
       utf-8-validate: 5.0.10
-
-  ws@5.2.3:
-    dependencies:
-      async-limiter: 1.0.1
 
   ws@5.2.3(bufferutil@4.0.8)(utf-8-validate@5.0.10):
     dependencies:
@@ -11770,8 +11635,6 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.0.8
       utf-8-validate: 5.0.10
-
-  ws@8.5.0: {}
 
   ws@8.5.0(bufferutil@4.0.8)(utf-8-validate@5.0.10):
     optionalDependencies:

--- a/src/LSP2ERC725YJSONSchema/decodeAssetUrl/decodeAssetUrl.test.ts
+++ b/src/LSP2ERC725YJSONSchema/decodeAssetUrl/decodeAssetUrl.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { decodeAssetUrl } from '../..';
+import { SUPPORTED_VERIFICATION_METHOD_HASHES } from '@erc725/erc725.js/build/main/src/constants/constants';
 
 describe('decodeAssetUrl', () => {
     it('should pass if ASSETURL has bytes length bigger than 36', () => {
@@ -7,7 +8,7 @@ describe('decodeAssetUrl', () => {
             '0x6f357c6a2a04850096912391bbb0966a624519e8f5d797df2a2c47425e892c25e00c053568747470733a2f2f676f6f676c652e636f6d2f';
 
         const expectedJsonUrl = {
-            hashFunction: '0x6f357c6a',
+            hashFunction: SUPPORTED_VERIFICATION_METHOD_HASHES.HASH_KECCAK256_UTF8,
             hash: '0x2a04850096912391bbb0966a624519e8f5d797df2a2c47425e892c25e00c0535',
             url: 'https://google.com/',
         };
@@ -20,7 +21,7 @@ describe('decodeAssetUrl', () => {
             '0x6f357c6a2a04850096912391bbb0966a624519e8f5d797df2a2c47425e892c25e00c0535';
 
         const expectedJsonUrl = {
-            hashFunction: '0x6f357c6a',
+            hashFunction: SUPPORTED_VERIFICATION_METHOD_HASHES.HASH_KECCAK256_UTF8,
             hash: '0x2a04850096912391bbb0966a624519e8f5d797df2a2c47425e892c25e00c0535',
             url: '',
         };

--- a/src/LSP2ERC725YJSONSchema/decodeJsonUrl/decodeJsonUrl.test.ts
+++ b/src/LSP2ERC725YJSONSchema/decodeJsonUrl/decodeJsonUrl.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { decodeJsonUrl } from '../..';
+import { SUPPORTED_VERIFICATION_METHOD_HASHES } from '@erc725/erc725.js/build/main/src/constants/constants';
 
 describe('decodeJsonUrl', () => {
     it('should pass if JSONURL has bytes length bigger than 36', () => {
@@ -7,7 +8,7 @@ describe('decodeJsonUrl', () => {
             '0x6f357c6a4dade694d7dd4081f46073e99ce898a9b53cf6988452904de7db5cc704a4184968747470733a2f2f676f6f676c652e636f6d2f';
 
         const expectedJsonUrl = {
-            hashFunction: '0x6f357c6a',
+            hashFunction: SUPPORTED_VERIFICATION_METHOD_HASHES.HASH_KECCAK256_UTF8,
             hash: '0x4dade694d7dd4081f46073e99ce898a9b53cf6988452904de7db5cc704a41849',
             url: 'https://google.com/',
         };
@@ -20,7 +21,7 @@ describe('decodeJsonUrl', () => {
             '0x6f357c6a4dade694d7dd4081f46073e99ce898a9b53cf6988452904de7db5cc704a41849';
 
         const expectedJsonUrl = {
-            hashFunction: '0x6f357c6a',
+            hashFunction: SUPPORTED_VERIFICATION_METHOD_HASHES.HASH_KECCAK256_UTF8,
             hash: '0x4dade694d7dd4081f46073e99ce898a9b53cf6988452904de7db5cc704a41849',
             url: '',
         };

--- a/src/LSP2ERC725YJSONSchema/decodeVerifiableURI/decodeVerifiableURI.test.ts
+++ b/src/LSP2ERC725YJSONSchema/decodeVerifiableURI/decodeVerifiableURI.test.ts
@@ -1,0 +1,18 @@
+import { expect } from 'chai';
+import { decodeVerifiableURI } from './decodeVerifiableURI';
+
+describe('testing `decodeVerifiableURI`', () => {
+    it('Decoding a Verifiable URI', () => {
+        const data =
+            '0x00006f357c6a0020eaba44f326e1405eed836279c9bdb0d62b6f8f7a6187f4fb8454607afd550ee368747470733a2f2f676f6f676c652e636f6d2f';
+        const decodedData = decodeVerifiableURI(data);
+
+        expect(decodedData).to.deep.equal({
+            verification: {
+                method: 'keccak256(utf8)',
+                data: '0xeaba44f326e1405eed836279c9bdb0d62b6f8f7a6187f4fb8454607afd550ee3',
+            },
+            url: 'https://google.com/',
+        });
+    });
+});

--- a/src/LSP2ERC725YJSONSchema/decodeVerifiableURI/decodeVerifiableURI.ts
+++ b/src/LSP2ERC725YJSONSchema/decodeVerifiableURI/decodeVerifiableURI.ts
@@ -1,0 +1,24 @@
+import { decodeValueContent } from '@erc725/erc725.js';
+
+/**
+ * Decode a VerifableURI value content.
+ *
+ * @category LSP2
+ * @param data A value encoded as VerifiableURI
+ *
+ * @see https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md
+ * @example
+ * ```ts
+ * decodeVerifiableURI("0x00006f357c6a0020eaba44f326e1405eed836279c9bdb0d62b6f8f7a6187f4fb8454607afd550ee368747470733a2f2f676f6f676c652e636f6d2f") =>
+ * {
+ *     verification: {
+ *         method: 'keccak256(utf8)',
+ *         data: '0xeaba44f326e1405eed836279c9bdb0d62b6f8f7a6187f4fb8454607afd550ee3',
+ *     },
+ *     url: 'https://google.com/',
+ * }
+ * ```
+ */
+export const decodeVerifiableURI = (data: string) => {
+    return decodeValueContent('VerifiableURI', data);
+};

--- a/src/LSP2ERC725YJSONSchema/decodeVerifiableURI/index.ts
+++ b/src/LSP2ERC725YJSONSchema/decodeVerifiableURI/index.ts
@@ -1,0 +1,1 @@
+export { decodeVerifiableURI } from './decodeVerifiableURI';

--- a/src/LSP2ERC725YJSONSchema/encodeVerifiableURI/encodeVerifiableURI.test.ts
+++ b/src/LSP2ERC725YJSONSchema/encodeVerifiableURI/encodeVerifiableURI.test.ts
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+import { concat, hexlify, keccak256, toBeHex, toUtf8Bytes } from 'ethers';
+import { encodeVerifiableURI } from './encodeVerifiableURI';
+import { SUPPORTED_VERIFICATION_METHOD_HASHES } from '@erc725/erc725.js/build/main/src/constants/constants';
+
+describe('testing `encodeVerifiableURI`', () => {
+    it('should pass, when encoding random json with random url', () => {
+        const json = {
+            someData:
+                'Commodo fugiat labore ipsum do ullamco officia sunt commodo reprehenderit in anim mollit. Aute fugiat sunt dolor ut adipisicing dolor. Nostrud laboris ullamco eu eu sint laboris id aliqua. Ipsum consequat fugiat eiusmod irure non. Cillum exercitation reprehenderit ullamco irure sint labore duis cupidatat. Lorem veniam cillum tempor incididunt laboris veniam commodo consequat sint. Velit exercitation dolore consequat nostrud et minim cillum quis aute minim.',
+            comeHere: 'Dolore incididunt consectetur incididunt nulla.',
+        };
+        const url = 'https://google.com/';
+
+        const encodedData = encodeVerifiableURI(json, url);
+
+        expect(encodedData).to.equal(
+            concat([
+                toBeHex(0, 2),
+                SUPPORTED_VERIFICATION_METHOD_HASHES.HASH_KECCAK256_UTF8,
+                toBeHex(32, 2),
+                hexlify(keccak256(toUtf8Bytes(JSON.stringify(json)))),
+                toUtf8Bytes(url),
+            ]),
+        );
+    });
+});

--- a/src/LSP2ERC725YJSONSchema/encodeVerifiableURI/encodeVerifiableURI.ts
+++ b/src/LSP2ERC725YJSONSchema/encodeVerifiableURI/encodeVerifiableURI.ts
@@ -1,0 +1,33 @@
+import { encodeValueContent } from '@erc725/erc725.js';
+import { validateJson } from '../../helpers/validateJson/validateJson';
+
+/**
+ * Encode a VerifiableURI value content.
+ *
+ * @category LSP2
+ *
+ * @param json The JSON file content hosted at `url`.
+ * @param url The URL where the JSON file is hosted.
+ *
+ * @return The encoded value as `VerifiableURI`.
+ *
+ * @see https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md
+ * @example
+ * ```ts
+ * encodeVerifiableURI(
+ *   {
+ *        "name": "Tom",
+ *        "description": "Some random description about Tom"
+ *   },
+ *   "https://google.com/"
+ * ) => "0x6f357c6a4dade694d7dd4081f46073e99ce898a9b53cf6988452904de7db5cc704a4184968747470733a2f2f676f6f676c652e636f6d2f"
+ * ```
+ */
+export const encodeVerifiableURI = (json: object, url: string) => {
+    const validatedJson = validateJson(json);
+
+    return encodeValueContent('VerifiableURI', {
+        json: validatedJson,
+        url,
+    });
+};

--- a/src/LSP2ERC725YJSONSchema/encodeVerifiableURI/index.ts
+++ b/src/LSP2ERC725YJSONSchema/encodeVerifiableURI/index.ts
@@ -1,0 +1,1 @@
+export { encodeVerifiableURI } from './encodeVerifiableURI';

--- a/src/LSP2ERC725YJSONSchema/index.ts
+++ b/src/LSP2ERC725YJSONSchema/index.ts
@@ -1,5 +1,7 @@
+export { decodeVerifiableURI } from './decodeVerifiableURI';
 export { decodeAssetUrl } from './decodeAssetUrl';
 export { decodeJsonUrl } from './decodeJsonUrl';
+export { encodeVerifiableURI } from './encodeVerifiableURI';
 export { encodeAssetUrl } from './encodeAssetUrl';
 export { encodeJsonUrl } from './encodeJsonUrl';
 export { generateArrayElementKeyAtIndex } from './generateArrayElementKeyAtIndex';

--- a/src/LSP3ProfileMetadata/index.ts
+++ b/src/LSP3ProfileMetadata/index.ts
@@ -1,2 +1,3 @@
 export { getProfileMetadata } from './getProfileMetadata';
 export { isProfileMetadata } from './isProfileMetadata';
+export { setProfileMetadata } from './setProfileMetadata';

--- a/src/LSP3ProfileMetadata/isProfileMetadata/isProfileMetadata.test.ts
+++ b/src/LSP3ProfileMetadata/isProfileMetadata/isProfileMetadata.test.ts
@@ -8,7 +8,7 @@ describe('isProfileMetadata', () => {
     });
 
     it('should return false if an object of type other than `LSP3ProfileMetadata` is passed', () => {
-        const object = { description: '', links: [], name: '', tags: [] };
+        const object = { description: '', links: [], tags: [] };
 
         expect(isProfileMetadata(object)).to.be.false;
     });

--- a/src/LSP3ProfileMetadata/isProfileMetadata/isProfileMetadata.ts
+++ b/src/LSP3ProfileMetadata/isProfileMetadata/isProfileMetadata.ts
@@ -1,7 +1,7 @@
 import { LSP3ProfileMetadataJSON } from '@lukso/lsp-smart-contracts';
 
 /**
- * Returns `true` is the passed object is an LSP3 Profile Metadata, `false` otherwise.
+ * Returns `true` if the passed object is an LSP3 Profile Metadata, `false` otherwise.
  *
  * @since v0.0.1
  * @category LSP3
@@ -20,11 +20,6 @@ export const isProfileMetadata = (
     return (
         'LSP3Profile' in object &&
         'name' in object.LSP3Profile &&
-        'description' in object.LSP3Profile &&
-        'links' in object.LSP3Profile &&
-        'tags' in object.LSP3Profile &&
-        'avatar' in object.LSP3Profile &&
-        'profileImage' in object.LSP3Profile &&
-        'backgroundImage' in object.LSP3Profile
+        'description' in object.LSP3Profile
     );
 };

--- a/src/LSP3ProfileMetadata/setProfileMetadata/index.ts
+++ b/src/LSP3ProfileMetadata/setProfileMetadata/index.ts
@@ -1,0 +1,1 @@
+export { setProfileMetadata } from './setProfileMetadata';

--- a/src/LSP3ProfileMetadata/setProfileMetadata/setProfileMetadata.test.ts
+++ b/src/LSP3ProfileMetadata/setProfileMetadata/setProfileMetadata.test.ts
@@ -1,0 +1,40 @@
+import { expect } from 'chai';
+import { setProfileMetadata } from './setProfileMetadata';
+import { ZeroAddress } from 'ethers';
+import { ERC725Y } from '../../typechain/erc725';
+import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts';
+import { encodeVerifiableURI } from '../../LSP2ERC725YJSONSchema';
+
+class MockERC725Y {
+    _store: Record<string, string> = {};
+
+    getAddress = async () => ZeroAddress;
+    supportsInterface = async (interfaceId: string) => true;
+
+    setData = async (dataKey: string, dataValue: string) => {
+        this._store[dataKey] = dataValue;
+    };
+    getData = async (dataKey: string) => {
+        return this._store[dataKey];
+    };
+}
+
+describe('testing `setProfileMetadata`', () => {
+    const mockErc725y = new MockERC725Y() as unknown as ERC725Y;
+    const metadata = {
+        LSP3Profile: {
+            name: 'Your Name',
+            description:
+                'Anim magna pariatur velit ex consequat. Exercitation veniam anim labore do ad. Ex exercitation veniam veniam ex dolor ullamco sit id proident sint consequat nulla. Exercitation id duis voluptate occaecat enim ea do in. Eu ut minim voluptate commodo excepteur.',
+        },
+    };
+    const url = 'https://google.com/';
+
+    it('should update the Profile metadata of a ERC725Y contract', async () => {
+        await setProfileMetadata(mockErc725y, metadata, url);
+
+        expect(await mockErc725y.getData(ERC725YDataKeys.LSP3.LSP3Profile)).to.equal(
+            encodeVerifiableURI(metadata, url),
+        );
+    });
+});

--- a/src/LSP3ProfileMetadata/setProfileMetadata/setProfileMetadata.ts
+++ b/src/LSP3ProfileMetadata/setProfileMetadata/setProfileMetadata.ts
@@ -1,0 +1,64 @@
+import { BytesLike, Signer, Wallet } from 'ethers';
+import { LSP3ProfileMetadataJSON } from '@lukso/lsp-smart-contracts';
+import { ERC725Y } from '../../typechain/erc725';
+import { getErc725yContract } from '../../helpers';
+
+import ERC725 from '@erc725/erc725.js';
+import LSP3Schema from '@erc725/erc725.js/schemas/LSP3ProfileMetadata.json';
+import { validateJson } from '../../helpers/validateJson';
+
+const erc725 = new ERC725(LSP3Schema);
+
+/**
+ * Set Profile metadata.
+ *
+ * @category LSP3
+ *
+ * @param erc725y The address of the Profile to set the metadata for.
+ * @param json The JSON file content hosted at `url`.
+ * @param url The URL where the JSON file is hosted.
+ * @param signer The ethers `Signer`, address that is allowed to modify the Profile metadata.
+ *
+ * @see https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-3-Profile-Metadata.md
+ * @example
+ * ```ts
+ * setProfileMetadata(
+ *   "0x..."
+ *   {
+ *     LSP3Profile: {
+ *       "name": "Tom",
+ *       "description": "Some random description about Tom"
+ *     }
+ *   },
+ *   "https://google.com/",
+ *   signer
+ * )
+ * ```
+ */
+export async function setProfileMetadata(
+    erc725y: ERC725Y | BytesLike,
+    json: LSP3ProfileMetadataJSON,
+    url: string,
+    signer?: Signer | Wallet,
+): Promise<void> {
+    const erc725yContract: ERC725Y = signer
+        ? await getErc725yContract(erc725y, signer)
+        : await getErc725yContract(erc725y);
+
+    const validatedJson = validateJson(json);
+
+    const {
+        keys: [dataKey],
+        values: [dataValue],
+    } = erc725.encodeData([
+        {
+            keyName: 'LSP3Profile',
+            value: {
+                url,
+                json: validatedJson,
+            },
+        },
+    ]);
+
+    await erc725yContract.setData(dataKey, dataValue);
+}

--- a/src/LSP4DigitalAssetMetadata/isAssetMetadata/isAssetMetadata.ts
+++ b/src/LSP4DigitalAssetMetadata/isAssetMetadata/isAssetMetadata.ts
@@ -1,12 +1,15 @@
 import { LSP4DigitalAssetMetadataJSON } from '@lukso/lsp-smart-contracts';
 
 /**
- * Returns `true` is the passed object is an LSP4 Asset Metadata, `false` otherwise.
+ * Returns `true` if the passed object is an LSP4 Asset Metadata, `false` otherwise.
  *
  * @since v0.0.1
  * @category LSP4
  * @param object - The object that is to be checked.
  * @see https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-3-Profile-Metadata.md
+ *
+ * @returns A boolean. `true` if object is `LSP4DigitalAssetMetadataJSON`, `false` otherwise.
+ *
  * @example
  * ```ts
  * isAssetMetadata({ LSP4Metadata: { description: "", links: [], images: [], assets: [] icon: [] } }) => true
@@ -19,6 +22,7 @@ export const isAssetMetadata = (
 ): object is LSP4DigitalAssetMetadataJSON => {
     return (
         'LSP4Metadata' in object &&
+        'name' in object.LSP4Metadata &&
         'description' in object.LSP4Metadata &&
         'links' in object.LSP4Metadata &&
         'images' in object.LSP4Metadata &&

--- a/src/LSP4DigitalAssetMetadata/setAssetMetadata/index.ts
+++ b/src/LSP4DigitalAssetMetadata/setAssetMetadata/index.ts
@@ -1,0 +1,1 @@
+export { setAssetMetadata } from './setAssetMetadata';

--- a/src/LSP4DigitalAssetMetadata/setAssetMetadata/setAssetMetadata.test.ts
+++ b/src/LSP4DigitalAssetMetadata/setAssetMetadata/setAssetMetadata.test.ts
@@ -1,0 +1,40 @@
+import { expect } from 'chai';
+import { setAssetMetadata } from './setAssetMetadata';
+import { ZeroAddress } from 'ethers';
+import { ERC725Y } from '../../typechain/erc725';
+import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts';
+import { encodeVerifiableURI } from '../../LSP2ERC725YJSONSchema';
+
+class MockERC725Y {
+    _store: Record<string, string> = {};
+
+    getAddress = async () => ZeroAddress;
+    supportsInterface = async (interfaceId: string) => true;
+
+    setData = async (dataKey: string, dataValue: string) => {
+        this._store[dataKey] = dataValue;
+    };
+    getData = async (dataKey: string) => {
+        return this._store[dataKey];
+    };
+}
+
+describe('testing `setAssetMetadata`', () => {
+    const mockErc725y = new MockERC725Y() as unknown as ERC725Y;
+    const metadata = {
+        LSP3Profile: {
+            name: 'Your Name',
+            description:
+                'Anim magna pariatur velit ex consequat. Exercitation veniam anim labore do ad. Ex exercitation veniam veniam ex dolor ullamco sit id proident sint consequat nulla. Exercitation id duis voluptate occaecat enim ea do in. Eu ut minim voluptate commodo excepteur.',
+        },
+    };
+    const url = 'https://google.com/';
+
+    it('should update the Asset metadata', async () => {
+        await setAssetMetadata(mockErc725y, metadata, url);
+
+        expect(await mockErc725y.getData(ERC725YDataKeys.LSP3.LSP3Profile)).to.equal(
+            encodeVerifiableURI(metadata, url),
+        );
+    });
+});

--- a/src/LSP4DigitalAssetMetadata/setAssetMetadata/setAssetMetadata.ts
+++ b/src/LSP4DigitalAssetMetadata/setAssetMetadata/setAssetMetadata.ts
@@ -1,0 +1,68 @@
+import { BytesLike, Signer, Wallet } from 'ethers';
+import { LSP4DigitalAssetMetadataJSON } from '@lukso/lsp-smart-contracts';
+import { ERC725Y } from '../../typechain/erc725';
+import { getErc725yContract } from '../../helpers';
+
+import ERC725 from '@erc725/erc725.js';
+import LSP3Schema from '@erc725/erc725.js/schemas/LSP3ProfileMetadata.json';
+import { validateJson } from '../../helpers/validateJson';
+
+const erc725 = new ERC725(LSP3Schema);
+
+/**
+ * Set Asset metadata.
+ *
+ * @category LSP4
+ *
+ * @param erc725y The address of the Asset to set the metadata for.
+ * @param json The JSON file content hosted at `url`.
+ * @param url The URL where the JSON file is hosted.
+ * @param signer The ethers `Signer`, address that is allowed to modify the Asset metadata.
+ *
+ * @see https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-3-Profile-Metadata.md
+ * @example
+ * ```ts
+ * setAssetMetadata(
+ *   "0x..."
+ *   {
+ *     LSP4Metadata: {
+ *       "name": "Chillwhales",
+ *       "description": "Some random description about Chillwhales",
+ *       "links": [...];
+ *       "images": [...];
+ *       "assets": [...];
+ *       "icon": [...];
+ *     }
+ *   },
+ *   "https://google.com/",
+ *   signer
+ * )
+ * ```
+ */
+export async function setAssetMetadata(
+    digitalAsset: ERC725Y | BytesLike,
+    json: LSP4DigitalAssetMetadataJSON,
+    url: string,
+    signer?: Signer | Wallet,
+): Promise<void> {
+    const digitalAssetContract: ERC725Y = signer
+        ? await getErc725yContract(digitalAsset, signer)
+        : await getErc725yContract(digitalAsset);
+
+    const validatedJson = validateJson(json);
+
+    const {
+        keys: [dataKey],
+        values: [dataValue],
+    } = erc725.encodeData([
+        {
+            keyName: 'LSP3Profile',
+            value: {
+                url,
+                json: validatedJson,
+            },
+        },
+    ]);
+
+    await digitalAssetContract.setData(dataKey, dataValue);
+}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -14,11 +14,13 @@ export const defaultLSP3ProfileMetadata: LSP3ProfileMetadataJSON = {
 
 export const defaultLSP4AssetMetadata: LSP4DigitalAssetMetadataJSON = {
     LSP4Metadata: {
+        name: '',
         description: '',
         links: [],
-        icon: [],
         images: [],
         assets: [],
+        icon: [],
+        attributes: [],
     },
 };
 

--- a/src/helpers/validateJson/index.ts
+++ b/src/helpers/validateJson/index.ts
@@ -1,0 +1,1 @@
+export { validateJson } from './validateJson';

--- a/src/helpers/validateJson/validateJson.test.ts
+++ b/src/helpers/validateJson/validateJson.test.ts
@@ -1,0 +1,30 @@
+import { expect } from 'chai';
+import { validateJson } from './validateJson';
+
+describe('testing `validateJson`', () => {
+    it('should revert when passing a string as json', () => {
+        const json = 'some random string';
+
+        expect(() => validateJson(json as unknown as object)).to.throw(
+            '`object` is not a valid JSON',
+        );
+    });
+
+    it('should revert when passing a number as json', () => {
+        const json = 312321;
+
+        expect(() => validateJson(json as unknown as object)).to.throw(
+            '`object` is not a valid JSON',
+        );
+    });
+
+    it('should pass when passing a valid object as json', () => {
+        const json = {
+            data: 'some text',
+            index: 10,
+            value: 'blah blah',
+        };
+
+        expect(validateJson(json as unknown as object)).to.equal(json);
+    });
+});

--- a/src/helpers/validateJson/validateJson.ts
+++ b/src/helpers/validateJson/validateJson.ts
@@ -1,0 +1,21 @@
+/**
+ * Verify that the `json` object is a valid JSON
+ *
+ * @category Helpers
+ * @param json JSON file content
+ * @returns The `json` object
+ */
+export const validateJson = (json: object) => {
+    if (typeof json !== 'object') {
+        throw new Error('`object` is not a valid JSON');
+    }
+
+    try {
+        const stringifyResult = JSON.stringify(json);
+        JSON.parse(stringifyResult);
+    } catch (error) {
+        throw new Error('`object` is not a valid JSON');
+    }
+
+    return json;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,8 +27,10 @@ export { validateIpfsUrl } from './IPFS';
 
 // ------ LSP2 ------
 export {
+    decodeVerifiableURI,
     decodeAssetUrl,
     decodeJsonUrl,
+    encodeVerifiableURI,
     encodeAssetUrl,
     encodeJsonUrl,
     generateArrayElementKeyAtIndex,
@@ -43,7 +45,7 @@ export {
 } from './LSP2ERC725YJSONSchema';
 
 // ------ LSP3 ------
-export { getProfileMetadata, isProfileMetadata } from './LSP3ProfileMetadata';
+export { getProfileMetadata, isProfileMetadata, setProfileMetadata } from './LSP3ProfileMetadata';
 
 // ------ LSP4 ------
 export {


### PR DESCRIPTION
# What does this PR introduce?
- Bump `lsp-smart-contracts` version
- Bump `erc725.js` version
- Add support for VerifableURI
- Add `setProfileMetadata`
- Add `setAssetMetadata`