### PR TITLE
Fix allowed keys encoding

### DIFF
--- a/src/LSP6KeyManager/encodeAllowedERC725YDataKeys/encodeAllowedERC725YDataKeys.test.ts
+++ b/src/LSP6KeyManager/encodeAllowedERC725YDataKeys/encodeAllowedERC725YDataKeys.test.ts
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
 import { encodeAllowedERC725YDataKeys } from '../..';
+import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts';
 
-describe('encodeAllowedERC725YDataKeys.test', () => {
+describe('test `encodeAllowedERC725YDataKeys`', () => {
     it('should throw if a passed data key is UTF8', () => {
         const dataKeys = ['data key'];
 
@@ -29,6 +30,21 @@ describe('encodeAllowedERC725YDataKeys.test', () => {
             `Invalid length. Length: '${
                 dataKeys[0].length / 2 - 1
             }'. Must be bigger than 0 and smaller than 32.`,
+        );
+    });
+
+    it('should pass if the passed data keys are valid', () => {
+        const dataKeys = [
+            ERC725YDataKeys.LSP4['LSP4Creators[]'].index,
+            ERC725YDataKeys.LSP4.LSP4CreatorsMap,
+            ERC725YDataKeys.LSP12['LSP12IssuedAssets[]'].index,
+            ERC725YDataKeys.LSP12.LSP12IssuedAssetsMap,
+        ];
+
+        const encodedAllowedERC725YDataKeys = encodeAllowedERC725YDataKeys(dataKeys);
+
+        expect(encodedAllowedERC725YDataKeys).to.equal(
+            '0x0010114bd03b3a46d48759680d81ebb2b414000c6de85eaf5d982b4e5da0000000107c8c3416d6cda87cd42c71ea1843df28000c74ac2555c10b9349e78f0000',
         );
     });
 });

--- a/src/LSP6KeyManager/encodeAllowedERC725YDataKeys/encodeAllowedERC725YDataKeys.ts
+++ b/src/LSP6KeyManager/encodeAllowedERC725YDataKeys/encodeAllowedERC725YDataKeys.ts
@@ -42,7 +42,7 @@ export const encodeAllowedERC725YDataKeys = (dataKeys: BytesLike[]) => {
             );
         }
 
-        compactedBytes += toBeHex(strippedDataKey.length, 2).substring(2) + strippedDataKey;
+        compactedBytes += toBeHex(strippedDataKey.length / 2, 2).substring(2) + strippedDataKey;
     }
 
     return compactedBytes;


### PR DESCRIPTION
# What does this PR introduce?

This PR adds a fix and a test to make sure encoding Allowed ERC725Y Data Keys is correct