### PR TITLE
fix: offset index by issued assets length

### DIFF
--- a/src/LSP12IssuedAssets/addIssuedAssets/addIssuedAssets.ts
+++ b/src/LSP12IssuedAssets/addIssuedAssets/addIssuedAssets.ts
@@ -73,7 +73,7 @@ export async function addIssuedAssets(
         toBeHex(issuedAssetsLength + newIssuedAssets.length, 16),
         ...newIssuedAssets.flatMap((newIssuedAsset, index) => [
             newIssuedAsset.address.toString(),
-            concat([newIssuedAsset.interfaceId, toBeHex(index, 16)]),
+            concat([newIssuedAsset.interfaceId, toBeHex(issuedAssetsLength + index, 16)]),
         ]),
     ];
 


### PR DESCRIPTION
If the index is not offset by the issued assets length it will always start by 0